### PR TITLE
change default  argument of `meta_data_merge`

### DIFF
--- a/bdpy/bdata/utils.py
+++ b/bdpy/bdata/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 from .bdata import BData
 
 
-def vstack(bdata_list, successive=[], metadata_merge='strict', ignore_metadata_description=False):
+def vstack(bdata_list, successive=[], metadata_merge='minimal', ignore_metadata_description=False):
     '''Concatenate datasets vertically.
 
     Currently, `concat_dataset` does not validate the consistency of meta-data


### PR DESCRIPTION
In python3, it seems error when calling `vstack` function  for `metadata_merge='strict'`. I changed to`metadata_merge='minimal'` and it worked well. Please consider changing or checking `metadata_equal` function in lines 63. Thank you.