### PR TITLE
[feat] add rounding option to add_roimask

### DIFF
--- a/bdpy/mri/roi.py
+++ b/bdpy/mri/roi.py
@@ -16,15 +16,16 @@ from bdpy.mri import load_mri
 def add_roimask(bdata, roi_mask, roi_prefix='',
                 brain_data='VoxelData', xyz=['voxel_x', 'voxel_y', 'voxel_z'],
                 return_roi_flag=False,
-                verbose=True):
+                verbose=True,
+                round=None):
     '''Add an ROI mask to `bdata`.
-
     Parameters
     ----------
     bdata : BData
     roi_mask : str or list
         ROI mask file(s).
-
+    round :  int
+        Number of decimal places to round the voxel coordinate.
     Returns
     -------
     bdata : BData
@@ -38,6 +39,9 @@ def add_roimask(bdata, roi_mask, roi_prefix='',
                            bdata.get_metadata(xyz[1], where=brain_data),
                            bdata.get_metadata(xyz[2], where=brain_data)])
 
+    if round is not None:
+        voxel_xyz = np.round(voxel_xyz, round)
+
     # Load the ROI mask files
     mask_xyz_all = []
     mask_v_all = []
@@ -46,6 +50,8 @@ def add_roimask(bdata, roi_mask, roi_prefix='',
 
     for m in roi_mask:
         mask_v, mask_xyz, mask_ijk = load_mri(m)
+        if round is not None:
+            mask_xyz = np.round(mask_xyz, round)
         mask_v_all.append(mask_v)
         mask_xyz_all.append(mask_xyz[:, (mask_v == 1).flatten()])
 
@@ -56,7 +62,7 @@ def add_roimask(bdata, roi_mask, roi_prefix='',
     if voxel_consistency:
         roi_flag = np.vstack(mask_v_all)
     else:
-        roi_flag = get_roiflag(mask_xyz_all, voxel_xyz)
+        roi_flag = get_roiflag(mask_xyz_all, voxel_xyz, verbose=verbose)
 
     # Add the ROI flag as metadata in `bdata`
     md_keys = []
@@ -69,9 +75,9 @@ def add_roimask(bdata, roi_mask, roi_prefix='',
             roi_md5 = hashlib.md5(f.read()).hexdigest()
 
         roi_desc = '1 = ROI %s (source file: %s; md5: %s)' % (roi_name, roi, roi_md5)
-
-        print('Adding %s' % roi_name)
-        print('  %s' % roi_desc)
+        if verbose:
+            print('Adding %s' % roi_name)
+            print('  %s' % roi_desc)
         md_keys.append(roi_name)
         md_descs.append(roi_desc)
 
@@ -89,6 +95,7 @@ def add_roimask(bdata, roi_mask, roi_prefix='',
         return bdata, roi_flag
     else:
         return bdata
+
 
 
 def get_roiflag(roi_xyz_list, epi_xyz_array, verbose=True):


### PR DESCRIPTION
Added rounding option to roi addition to avoid small fraction differences in ROI coordinate alignment. This small fraction difference often occurs with FreeSurfer 6.0 vol2vol commands leading bdpy to not find any voxels in the aligned roi. Also fixed the unused verbose option.