### PR TITLE
[fix] mistype

### DIFF
--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -99,7 +99,7 @@ class ImageDataset(torch.utils.data.Dataset):
         self.__shape = shape
         self.__resize = resize
         self.__scale = scale
-        self.rgb_mean = rgb_mean
+        self.__rgb_mean = rgb_mean
 
         self.__data = {}
         preload_size = 0


### PR DESCRIPTION
Sorry for the repeated pull requests. I mistook the definition of rgb_mean as class-variables.
I confirmed operation in my local environment.