### PR TITLE
[add] add resolve_map

### DIFF
--- a/bdpy/bdata/utils.py
+++ b/bdpy/bdata/utils.py
@@ -137,6 +137,8 @@ def resolve_vmap(bdata_list):
         # Check each bdata vmap.
         for ds in bdata_list:
             vmap = ds.get_vmap(vmap_key)
+            ds_values, selector = ds.select(vmap_key, return_index = True) # keep original dataset values
+            new_dsvalues = copy.deepcopy(ds_values)  # to update
             
             # Sanity check
             if not vmap_key in ds.metadata.key:
@@ -157,13 +159,14 @@ def resolve_vmap(bdata_list):
                     # assign a new key by incrementing 1 to the maximum exisiting key.
                     inflation_key_value = max(new_vmap.keys()) 
                     new_vmap[inflation_key_value + 1] = vmap[vk]
-                    # Fix values in dataset.
-                    ds_values, selector = ds.select(vmap_key, return_index = True)
-                    ds_values[ds_values == vk] = inflation_key_value + 1
-                    ds.dataset[:, selector] = ds_values
+                    # Update dataset values
+                    new_dsvalues[ds_values == vk] = inflation_key_value + 1
                 else:
                     # If the key and value is same, nothing to do.
                     pass
+                
+            # Update dataset
+            ds.dataset[:, selector] = new_dsvalues
 
         # Update each bdata vmap.
         for ds in bdata_list:

--- a/bdpy/dataform/features.py
+++ b/bdpy/dataform/features.py
@@ -15,6 +15,7 @@ import os
 import glob
 import sqlite3
 import pickle
+import warnings
 
 import numpy as np
 import scipy.io as sio
@@ -306,8 +307,15 @@ class DecodedFeatures(object):
     def selected_label(self):
         return self.__db.get_selected_values('label')
 
-    def get(self, layer=None, subject=None, roi=None, fold=None, label=None):
+    def get(self, layer=None, subject=None, roi=None, fold=None, label=None, image=None):
         '''Returns decoded features as an array.'''
+
+        if image is not None:
+            if label is None:
+                warnings.warn('`image` will be deprecated.')
+                label = image
+            else:
+                warnings.warn('`image` will be deprecated and overwritten by `label`.')
 
         files = self.__db.get_file(
             layer=layer,

--- a/docs/dataform_features.md
+++ b/docs/dataform_features.md
@@ -1,0 +1,54 @@
+# Features and DecodedFeatures
+
+bdpy provides classes to handle DNN's (true) features and decoded features: `dataform.Features` and `dataform.DecodedFeatures`.
+
+## Basic usage
+
+``` python
+from bdpy.dataform import Features, DecodedFeatures
+
+
+## Initialize
+
+features = Features('/path/to/features/dir')
+
+decoded_features = DecodedFeatures('/path/to/decoded/features/dir')
+
+## Get features as an array
+
+feat = features.get(layer='conv1')
+
+decfeat = decoded_features.get(layer='conv1', subject='sub-01', roi='VC', label='stimulus-0001)  # Decoded features for specified sample (label)
+decfeat = decoded_features.get(layer='conv1', subject='sub-01', roi='VC')                        # Decoded features from all avaiable samples
+
+# Decoded features with CV
+decfeat = decoded_features.get(layer='conv1', subject='sub-01', roi='VC', fold='cv_fold1)
+
+## List labels
+
+feat_labels = features.labels
+
+decfeat_labels = decoded_features.labels           # All available labels
+decfeat_labels = decoded_features.selected_labels  # Labels assigned to decoded features previously obtained by `get` method
+```
+
+## Feature statistics
+
+``` python
+features.statistic('mean', layer='fc8')
+features.statistic('std', layer='fc8')          # Default ddof = 1
+features.statistic('std, ddof=0', layer='fc8')
+
+decoded_features.statistic('mean', layer='fc8', subject='sub-01', roi='VC')
+decoded_features.statistic('std', layer='fc8', subject='sub-01', roi='VC')          # Default ddof = 1
+decoded_features.statistic('std, ddof=0', layer='fc8', subject='sub-01', roi='VC')
+
+# Decoded features with CV
+decoded_features.statistic('mean', layer='fc8', subject='sub-01', roi='VC', fold='cv_fold1')  # Mean within the specified fold
+decoded_features.statistic('mean', layer='fc8', subject='sub-01', roi='VC')
+
+# If `fold` is omitted for CV decoded features, decoded features are pooled across add CV folds and then the statistics are calculated.
+
+```
+
+


### PR DESCRIPTION
bdataのリストを渡すと，リスト全体で一貫性のあるvmapを持つように各bdataを更新するresolve_map関数を追加しました．
複数のbdataを結合する際，いずれかのvmapにおいて衝突が発生する（同じ名前のkeyで異なるvalueを持つ）と，結合不可になる問題の解決のためです．
修正後のbdata_listの各bdataは，衝突の発生していたvmapについて全く同じvmap(dict)を持つようになります．
@ShuntaroAoki 
動作確認は2/6に連絡したディレクトリのデータで行いました．