### PR TITLE
[fix] fix generator_postproc

### DIFF
--- a/bdpy/recon/torch/icnn.py
+++ b/bdpy/recon/torch/icnn.py
@@ -337,7 +337,7 @@ def reconstruct(features,
             # xt.retain_grad()
 
             if generator_postproc is not None:
-                xt = generator.postproc(xt)
+                xt = generator_postproc(xt)
 
             # Crop the generated image
             if crop_generator_output:


### PR DESCRIPTION
generator_postproc の引数に対し，実行されるのが generator.postproc になっていたため，generator_postproc に修正しました．