### PR TITLE
Update feature extractor

### DIFF
--- a/bdpy/dl/torch/models.py
+++ b/bdpy/dl/torch/models.py
@@ -104,8 +104,12 @@ def _parse_layer_name(model: nn.Module, layer_name: str) -> nn.Module:
     if m is not None:
         layer_name = m.group('layer_name')
         index = int(m.group('index'))
-        return getattr(model, layer_name)[index]
-    raise ValueError('Invalid layer name: {}'.format(layer_name))
+        if hasattr(model, layer_name):
+            return getattr(model, layer_name)[index]
+
+    raise ValueError(
+        f"Invalid layer name: '{layer_name}'. Either the syntax of '{layer_name}' is not supported, "
+        f"or {type(model).__name__} object has no attribute '{layer_name}'.")
 
 
 class VGG19(nn.Module):

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -9,6 +9,8 @@ from PIL import Image
 import torch
 import torch.nn as nn
 
+_tensor_t = Union[np.ndarray, torch.Tensor]
+
 
 class FeatureExtractor(object):
     def __init__(
@@ -71,8 +73,8 @@ class ImageDataset(torch.utils.data.Dataset):
 
     def __init__(
             self, images: List[str], labels: Optional[List[str]] = None,
-            label_dirname: bool = False, resize: Optional[Tuple[int]] = None,
-            shape: str = 'chw', transform: Optional[Callable[[Union[np.ndarray, torch.Tensor]], torch.Tensor]] = None,
+            label_dirname: bool = False, resize: Optional[Tuple[int, int]] = None,
+            shape: str = 'chw', transform: Optional[Callable[[_tensor_t], torch.Tensor]] = None,
             scale: float = 1, rgb_mean: Optional[List[float]] = None, preload: bool = False, preload_limit: float = np.inf):
         '''
         Parameters
@@ -87,7 +89,7 @@ class ImageDataset(torch.utils.data.Dataset):
             If not None, images will be resized by the specified size.
         shape : str ({'chw', 'hwc', ...}), optional
             Specify array shape (channel, hieght, and width).
-        transform : optional
+        transform : Callable[[Union[np.ndarray, torch.Tensor]], torch.Tensor], optional
             Transformers (applied after resizing, reshaping, ans scaling to [0, 1])
         scale : optional
             Image intensity is scaled to [0, scale] (default: 1).

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -1,6 +1,6 @@
 '''PyTorch module.'''
 
-from typing import List, Dict, Union, Tuple, Any, Callable, Optional
+from typing import Iterable, List, Dict, Union, Tuple, Any, Callable, Optional
 
 import os
 
@@ -14,7 +14,7 @@ _tensor_t = Union[np.ndarray, torch.Tensor]
 
 class FeatureExtractor(object):
     def __init__(
-            self, encoder: nn.Module, layers: List[str],
+            self, encoder: nn.Module, layers: Iterable[str],
             layer_mapping: Optional[Dict[str, str]] = None,
             device: str = 'cpu', detach: bool = True):
         self._encoder = encoder

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -35,10 +35,10 @@ class FeatureExtractor(object):
             layer_object = models._parse_layer_name(self._encoder, layer)
             layer_object.register_forward_hook(self._extractor)
 
-    def __call__(self, x: Union[np.ndarray, torch.Tensor]) -> Dict[str, Union[np.ndarray, torch.Tensor]]:
+    def __call__(self, x: _tensor_t) -> Dict[str, _tensor_t]:
         return self.run(x)
 
-    def run(self, x: Union[np.ndarray, torch.Tensor]) -> Dict[str, Union[np.ndarray, torch.Tensor]]:
+    def run(self, x: _tensor_t) -> Dict[str, _tensor_t]:
         self._extractor.clear()
         if not isinstance(x, torch.Tensor):
             xt = torch.tensor(x[np.newaxis], device=self.__device)
@@ -47,7 +47,7 @@ class FeatureExtractor(object):
 
         self._encoder.forward(xt)
 
-        features: Dict[str, Union[np.ndarray, torch.Tensor]] = {
+        features: Dict[str, _tensor_t] = {
             layer: self._extractor.outputs[i]
             for i, layer in enumerate(self.__layers)
         }

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -9,6 +9,8 @@ from PIL import Image
 import torch
 import torch.nn as nn
 
+from . import models
+
 _tensor_t = Union[np.ndarray, torch.Tensor]
 
 
@@ -30,7 +32,8 @@ class FeatureExtractor(object):
         for layer in self.__layers:
             if self.__layer_map is not None:
                 layer = self.__layer_map[layer]
-            eval('self._encoder.{}.register_forward_hook(self._extractor)'.format(layer))
+            layer_object = models._parse_layer_name(self._encoder, layer)
+            layer_object.register_forward_hook(self._extractor)
 
     def __call__(self, x: Union[np.ndarray, torch.Tensor]) -> Dict[str, Union[np.ndarray, torch.Tensor]]:
         return self.run(x)

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -19,6 +19,23 @@ class FeatureExtractor(object):
             self, encoder: nn.Module, layers: Iterable[str],
             layer_mapping: Optional[Dict[str, str]] = None,
             device: str = 'cpu', detach: bool = True):
+        '''Feature extractor.
+
+        Parameters
+        ----------
+        encoder : torch.nn.Module
+            Network model we want to extract features from.
+        layers : Iterable[str]
+            List of layer names we want to extract features from.
+        layer_mapping : Dict[str, str], optional
+            Mapping from (human-readable) layer names to layer names in the model.
+            If None, layers will be directly used as layer names in the model.
+        device : str, optional
+            Device name (default: 'cpu').
+        detach : bool, optional
+            If True, detach the feature activations from the computation graph
+        '''
+
         self._encoder = encoder
         self.__layers = layers
         self.__layer_map = layer_mapping
@@ -39,6 +56,20 @@ class FeatureExtractor(object):
         return self.run(x)
 
     def run(self, x: _tensor_t) -> Dict[str, _tensor_t]:
+        '''Extract feature activations from the specified layers.
+
+        Parameters
+        ----------
+        x : numpy.ndarray or torch.Tensor
+            Input image (numpy.ndarray or torch.Tensor).
+
+        Returns
+        -------
+        features : Dict[str, Union[numpy.ndarray, torch.Tensor]]
+            Feature activations from the specified layers.
+            Each key is the layer name and each value is the feature activation.
+        '''
+
         self._extractor.clear()
         if not isinstance(x, torch.Tensor):
             xt = torch.tensor(x[np.newaxis], device=self.__device)

--- a/test/dl/torch/test_models.py
+++ b/test/dl/torch/test_models.py
@@ -56,6 +56,13 @@ class TestParseLayerName(unittest.TestCase):
             for attr, value in accessor['attrs'].items():
                 self.assertEqual(getattr(layer, attr), value)
 
+        # Test non-existing layer access
+        self.assertRaises(
+            ValueError, models._parse_layer_name, self.mock, 'not_existing_layer')
+        # Test invalid layer access
+        self.assertRaises(
+            ValueError, models._parse_layer_name, self.mock, 'layers["key"]')
+
 
 class TestVGG19(unittest.TestCase):
     def setUp(self):

--- a/test/dl/torch/test_models.py
+++ b/test/dl/torch/test_models.py
@@ -12,14 +12,14 @@ class MockModule(nn.Module):
         self.layer1 = nn.Linear(10, 10)
         self.layers = nn.Sequential(
             nn.Conv2d(1, 1, 3),
-            nn.Conv2d(1, 1, 3)
+            nn.Conv2d(1, 1, 3),
+            nn.Module()
         )
-        inner_network = nn.Module()
+        inner_network = self.layers[-1]
         inner_network.features = nn.Sequential(
             nn.Conv2d(1, 1, 5),
             nn.Conv2d(1, 1, 5)
         )
-        self.layers.append(inner_network)
 
 
 class TestLayerMap(unittest.TestCase):

--- a/test/dl/torch/test_torch.py
+++ b/test/dl/torch/test_torch.py
@@ -1,0 +1,78 @@
+import unittest
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from bdpy.dl.torch import torch as bdtorch
+
+
+class MockInnerModule(nn.Module):
+    def __init__(self):
+        super(MockInnerModule, self).__init__()
+        self.features = nn.Sequential(
+            nn.Linear(3, 4),
+            nn.Linear(4, 5)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.features(x)
+        return x
+
+
+class MockModule(nn.Module):
+    def __init__(self):
+        super(MockModule, self).__init__()
+        self.layer1 = nn.Linear(10, 1)
+        self.layers = nn.Sequential(
+            nn.Linear(1, 2),
+            nn.Linear(2, 3)
+        )
+        self.out = MockInnerModule()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.layer1(x)
+        x = self.layers(x)
+        x = self.out(x)
+        return x
+
+
+class TestFeatureExtractor(unittest.TestCase):
+    def setUp(self) -> None:
+        self.encoder = MockModule()
+        self.input_tensor = np.random.random(size=(10,)).astype(np.float32)
+        self.layer_list = [
+            {'map': {'alias': 'L1', 'entity': 'layer1'}, 'shape': (1, 1)},
+            {'map': {'alias': 'L2', 'entity': 'layers[0]'}, 'shape': (1, 2)},
+            {'map': {'alias': 'L3', 'entity': 'layers[1]'}, 'shape': (1, 3)},
+            {'map': {'alias': 'L4', 'entity': 'out.features[0]'}, 'shape': (1, 4)},
+            {'map': {'alias': 'L5', 'entity': 'out.features[1]'}, 'shape': (1, 5)}
+        ]
+
+    def test_run(self):
+        self.encoder.eval()
+        layer_to_shape = {payload['map']['entity']: payload['shape'] for payload in self.layer_list}
+        extractor = bdtorch.FeatureExtractor(self.encoder, layer_to_shape.keys(), detach=True)
+        features = extractor.run(self.input_tensor)
+        for layer, shape in layer_to_shape.items():
+            self.assertEqual(features[layer].shape, shape)
+
+    def test_run_with_layer_map(self):
+        self.encoder.eval()
+        layer_to_shape = {payload['map']['alias']: payload['shape'] for payload in self.layer_list}
+        layer_map = {payload['map']['alias']: payload['map']['entity'] for payload in self.layer_list}
+        extractor = bdtorch.FeatureExtractor(
+            self.encoder, layer_to_shape.keys(),
+            layer_mapping=layer_map, detach=True)
+        features = extractor.run(self.input_tensor)
+        for layer, shape in layer_to_shape.items():
+            self.assertEqual(features[layer].shape, shape)
+
+
+class TestImageDataset(unittest.TestCase):
+    ...
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestFeatureExtractor)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
We have implemented the followings:
- type annotations and docstrings for `dl/torch/torch.py`
- test code for `FeatureExtractor()`
- Stop using `eval()` function in `FeatureExtractor()`

Note:
- We have changed `layers` argument from an optional keyword argument to a positional argument. The reason for the interface change is based on [this](https://github.com/KamitaniLab/bdpy/pull/54#issuecomment-1473233253).
- We have not implemented the test code for `ImageDataset` dataset yet.

This PR will have the breaking change in bdpy's API. `FeatureExtractor()` now only accepts the layer name which has the following formats:
- `encoder.<layer>` can be directly accessible by `getattr` (e.g., `conv1`): `layer_object = getattr(encoder, layer)`
- `layer` is the combination of the instance variable name and index (e.g., `features[3]`): `layer_object = getattr(encoder, layer_name)[index]`
- `layer` is hierarchically composed of multiple objects (e.g., `resblock.conv1`): `layer_object = getattr(getattr(encoder, parent_name), child_name)`
- any combinations of the above situations (e.g., `transformer.resblocks[3].attn`)