### PR TITLE
[fix] feature extraction on detach

### DIFF
--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -16,7 +16,10 @@ class FeatureExtractor(object):
         self.__detach = detach
         self.__device = device
 
-        self._extractor = FeatureExtractorHandle()
+        if detach:
+            self._extractor = FeatureExtractorHandle_forExtract()
+        else:
+            self._extractor = FeatureExtractorHandle()
 
         self._encoder.to(self.__device)
 
@@ -51,6 +54,16 @@ class FeatureExtractor(object):
 
 
 class FeatureExtractorHandle(object):
+    def __init__(self):
+        self.outputs = []
+
+    def __call__(self, module, module_in, module_out):
+        self.outputs.append(module_out)
+
+    def clear(self):
+        self.outputs = []
+        
+class FeatureExtractorHandle_forExtract(object):
     def __init__(self):
         self.outputs = []
 


### PR DESCRIPTION
FeatureExtractorHandleについて，__call__の中でdetachする動作をデフォルトにすると，icnnで計算グラフが切れるバグが発生します．
従って，FeatureExtractorのdetach引数の値によって，detachするFeatureExtractorHandleクラスと，detachしないFeatureExtractorHandleクラスのどちらをインスタンスするかを切り替えています．
※ FeatureExtractorHandleにうまく引数を渡せなかったのでこのような形式にしていますが，もっと良い実装はあると思います．