### PR TITLE
[fix] fix icnn functions for channel selection

### DIFF
--- a/bdpy/recon/torch/icnn.py
+++ b/bdpy/recon/torch/icnn.py
@@ -382,8 +382,8 @@ def reconstruct(features,
 
             weight_j = layer_weights[lay]
 
-            masked_act_j = torch.masked_select(act_j, mask_j.bool()).view(act_j.shape)
-            masked_feat_j = torch.masked_select(feat_j, mask_j.bool()).view(feat_j.shape)
+            masked_act_j = torch.masked_select(act_j, mask_j.bool())
+            masked_feat_j = torch.masked_select(feat_j, mask_j.bool())
 
             loss_j = loss_func(masked_act_j, masked_feat_j) * weight_j
             loss += loss_j

--- a/bdpy/recon/utils.py
+++ b/bdpy/recon/utils.py
@@ -116,10 +116,10 @@ def make_feature_masks(features, masks, channels):
         elif isinstance(masks, dict) and (layer in masks.keys()) and isinstance(masks[layer], np.ndarray) and features[layer].ndim == 1 and masks[layer].ndim == 1 and masks[layer].shape[0] == features[layer].shape[0]:
             feature_masks[layer] = masks[layer]
         elif (masks is None or masks == {} or masks == [] or (layer not in masks.keys())) and isinstance(channels, dict) and (layer in channels.keys()) and isinstance(channels[layer], np.ndarray) and channels[layer].size > 0:  # select channels
-            mask_2D = np.ones_like(features[layer][0])
+            mask_2D = np.ones_like(features[layer][0][0]) 
             mask_3D = np.tile(mask_2D, [len(channels[layer]), 1, 1])
             feature_masks[layer] = np.zeros_like(features[layer])
-            feature_masks[layer][channels[layer], :, :] = mask_3D
+            feature_masks[layer][:, channels[layer], :, :] = mask_3D
         # use 2D mask select features for all channels
         elif isinstance(masks, dict) and (layer in masks.keys()) and isinstance(masks[layer], np.ndarray) and masks[layer].ndim == 2 and (channels is None or channels == {} or channels == [] or (layer not in channels.keys())):
             mask_2D_0 = masks[layer]


### PR DESCRIPTION
icnn再構成をする際の'channels'オプション周りの修正です．
utils.py(make_feature_masks関数)の方は，以前のsample次元を持たないときのままの実装になっていたため，そこに対応しました．ただし，修正した部分以外のif分岐については確認していません．
icnn.pyについては，maskをかけた後にviewをすることが本質的に不可能であったため，また，計算的にも不要であったため，その部分を削除しました．