### PR TITLE
Add the function to save the selected voxels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-# BdPy
+# BdPy_mtanaka
 
-[![PyPI version](https://badge.fury.io/py/bdpy.svg)](https://badge.fury.io/py/bdpy)
+[bdpy](https://github.com/KamitaniLab/bdpy) より下記の点を変更した．
+
+- `PyFastL2iR_mtanaka` に対応し，unit ごとに選択された voxel の index を保存する．
+
+## License
+
 [![GitHub license](https://img.shields.io/github/license/KamitaniLab/bdpy)](https://github.com/KamitaniLab/bdpy/blob/master/LICENSE)
 
 Python package for brain decoding analysis
 
 ## Requirements
 
-- Python 2.7, 3.6, or later
+- Python 3.5, or later
 - numpy
 - scipy
 - scikit-learn
@@ -37,42 +42,3 @@ Python package for brain decoding analysis
     - PyTorch
     - Pillow
 
-## Installation
-
-Latest stable release:
-
-``` shell
-$ pip install bdpy
-```
-
-To install the latest development version ("master" branch of the repository), please run the following command.
-
-```shell
-$ pip install git+https://github.com/KamitaniLab/bdpy.git
-```
-
-## Packages
-
-- bdata: BdPy data format (BData) core package
-- dataform: Utilities for various data format
-- distcomp: Distributed computation utilities
-- dl: Deep learning utilities
-- feature: Utilities for DNN features
-- fig: Utilities for figure creation
-- ml: Machine learning utilities
-- mri: MRI utilities
-- opendata: Open data utilities
-- preproc: Utilities for preprocessing
-- recon: Reconstruction methods
-- stats: Utilities for statistics
-- util: Miscellaneous utilities
-
-## BdPy data format
-
-BdPy data format (or BrainDecoderToolbox2 data format; BData) consists of two variables: dataset and metadata. **dataset** stores brain activity data (e.g., voxel signal value for fMRI data), target variables (e.g., ID of stimuli for vision experiments), and additional information specifying experimental design (e.g., run and block numbers for fMRI experiments). Each row corresponds to a single 'sample', and each column representes either single feature (voxel), target, or experiment design information. **metadata** contains data describing meta-information for each column in dataset.
-
-See [BData API examples](https://github.com/KamitaniLab/bdpy/blob/main/docs/bdata_api_examples.md) for useage of BData.
-
-## Developers
-
-- Shuntaro C. Aoki (Kyoto Univ)


### PR DESCRIPTION
unitごとに選択されたvoxelを記録するS.matを，W.matやb.matなどと同時に保存する機能を追加しました．また，predictの際にはこのS.matを読み出して選択voxelを復元します．
対応したPyFastL2LiRの更新を'relu_unit'ブランチでPRしています．
https://github.com/KamitaniLab/PyFastL2LiR/pull/5#issue-1729231162
なお，該当するbdpy/ml/learning.pyについて，現時点で最新のmainをmergeしています．