### PR TITLE
fix the behavior of _parse_layer_name

### DIFF
--- a/bdpy/dl/torch/models.py
+++ b/bdpy/dl/torch/models.py
@@ -1,5 +1,6 @@
 """Model definitions."""
 
+from __future__ import annotations
 
 from typing import Dict, Union, Optional, Sequence
 
@@ -127,7 +128,7 @@ def _parse_layer_name(model: nn.Module, layer_name: str) -> nn.Module:
     pattern = re.compile(r'^(?P<layer_name>[a-zA-Z_]+[a-zA-Z0-9_]*)?(?P<index>(\[(\d+)\])+)$')
     m = pattern.match(layer_name)
     if m is not None:
-        layer_name = m.group('layer_name')  # NOTE: layer_name can be None
+        layer_name: str | None = m.group('layer_name')  # NOTE: layer_name can be None
         index_str = m.group('index')
 
         indeces = re.findall(r'\[(\d+)\]', index_str)


### PR DESCRIPTION
Previous implementation cannot process the following code:


```python
import torch.nn as nn
from bdpy.dl.torch.models import _parse_layer_name
model = nn.Sequential(
    nn.Conv2d(3, 3, 3),
    nn.ReLU(),
)
_parse_layer_name(model, "[0]")
# ValueError: Invalid layer name: '[0]'. Either the syntax of '[0]' is not supported, or Sequential object has no attribute '[0]'.
```

`model[0]` returns `Conv2d` instance so we would expect the above code should work.

This is because `_parse_layer_name()` does not assume the direct submodule access using index slicing. We have updated the behavior of the `_parse_layer_name()` so that it can take them.