### PR TITLE
Fix issue #72 Forward Hooks Persist After Destroying FeatureExtractor

### DIFF
--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -95,10 +95,17 @@ class FeatureExtractor(object):
         return features
     
     def __del__(self):
-        '''Remove forward hooks from the encoder.'''
+        '''
+        Remove forward hooks for the FeatureExtractor while keeping
+        other forward hooks in the model.
+        '''
         for layer in self.__layers:
+            if self.__layer_map is not None:
+                layer = self.__layer_map[layer]
             layer_object = models._parse_layer_name(self._encoder, layer)
-            layer_object._forward_hooks = OrderedDict()
+            for key, hook in layer_object._forward_hooks.items():
+                if hook == self._extractor:
+                    del layer_object._forward_hooks[key]
 
 
 class FeatureExtractorHandle(object):

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -1,7 +1,7 @@
 '''PyTorch module.'''
 
 from typing import Iterable, List, Dict, Union, Tuple, Any, Callable, Optional
-
+from collections import OrderedDict
 import os
 
 import numpy as np
@@ -93,6 +93,12 @@ class FeatureExtractor(object):
             }
 
         return features
+    
+    def __del__(self):
+        '''Remove forward hooks from the encoder.'''
+        for layer in self.__layers:
+            layer_object = models._parse_layer_name(self._encoder, layer)
+            layer_object._forward_hooks = OrderedDict()
 
 
 class FeatureExtractorHandle(object):


### PR DESCRIPTION
This pull request fixes issue #72 where forward hooks on the encoder persist after destroying the FeatureExtractor. This issue caused unnecessary features to be stored incrementally, consuming RAM if the same encoder was used for another reconstruction. This pull request adds a destructor to the FeatureExtractor class that removes all forward hooks added by it. With these updates, the same encoder can be used for reconstruction multiple times without needing to be reloaded.