### PR TITLE
Add missing package imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyyaml",
     "pandas",
     "tqdm",
+    "typing-extensions>=4.5",
 ]
 
 [project.optional-dependencies]

--- a/tests/task/test_callback.py
+++ b/tests/task/test_callback.py
@@ -9,7 +9,7 @@ from bdpy.task import callback as callback_module
 
 
 # NOTE: setup functions
-def setup_fns() -> list[tuple[Callable, tuple[Any], Any]]:
+def setup_fns() -> list[tuple[Callable, tuple[Any, ...], Any]]:
     def f1(input_: Any) -> None:
         pass
 
@@ -71,7 +71,6 @@ class TestUnused(unittest.TestCase):
             ...
             RuntimeError: Function <function f at ...> is decorated with @unused and must not be called.
         """
-
         params = setup_fns()
         for fn, inputs_, output in params:
             self.assertTrue(


### PR DESCRIPTION
The newly implemented callback module used the typing_extensions package, but a dependency on this package was not explicitly stated in pyproject.toml, so this was added.