### PR TITLE
Introduce StandardizedDomain and ScaledDomain for improved API

### DIFF
--- a/tests/dl/torch/domain/test_image_domain.py
+++ b/tests/dl/torch/domain/test_image_domain.py
@@ -4,78 +4,109 @@ import unittest
 import torch
 import numpy as np
 import warnings
-from bdpy.dl.torch.domain import image_domain as iamge_domain_module
+from bdpy.dl.torch.domain import image_domain as image_domain_module
 
 
 class TestAffineDomain(unittest.TestCase):
     """Tests for bdpy.dl.torch.domain.image_domain.AffineDomain"""
     def setUp(self):
-        self.center0d = 0.0
-        self.center1d = np.random.randn(3)
-        self.center2d = np.random.randn(32, 32)
-        self.center3d = np.random.randn(3, 32, 32)
-        self.scale0d = 1
-        self.scale1d = np.random.randn(3)
-        self.scale2d = np.random.randn(32, 32)
-        self.scale3d = np.random.randn(3, 32, 32)
-        self.image = torch.rand((1, 3, 32, 32))
+        self.params = [
+            {"center": 0.2, "scale": 0.5, "dim": 0},
+            {"center": np.array([0.2, 0.3, 0.4]), "scale": np.array([0.5, 0.6, 0.7]), "dim": 1},
+            {"center": np.array([[0.2, 0.3], [0.4, 0.5]]), "scale": np.array([[0.5, 0.6], [0.7, 0.8]]), "dim": 2},
+            {"center": np.random.randn(3, 4, 4) * 0.1, "scale": np.random.randn(3, 4, 4) * 0.1, "dim": 3},
+        ]
 
     def test_instantiation(self):
         """Test instantiation."""
-        # Succeeds when center and scale are 0-dimensional
-        affine_domain = iamge_domain_module.AffineDomain(self.center0d, self.scale0d)
-        self.assertIsInstance(affine_domain, iamge_domain_module.AffineDomain)
+        for p in self.params:
+            with self.assertRaises(RuntimeError):
+                image_domain_module.AffineDomain(p["center"], p["scale"])
 
-        # Succeeds when center and scale are 1-dimensional
-        affine_domain = iamge_domain_module.AffineDomain(self.center1d, self.scale1d)
-        self.assertIsInstance(affine_domain, iamge_domain_module.AffineDomain)
 
-        # Succeeds when center and scale are 3-dimensional
-        affine_domain = iamge_domain_module.AffineDomain(self.center3d, self.scale3d)
-        self.assertIsInstance(affine_domain, iamge_domain_module.AffineDomain)
+class TestScaledDomain(unittest.TestCase):
+    """Tests for bdpy.dl.torch.domain.image_domain.ScaledDomain"""
+    def setUp(self):
+        self.scale = 0.5
+        self.image = torch.from_numpy(np.random.randn(1, 3, 4, 4))
+
+    def test_instantiation(self):
+        """Test instantiation."""
+        scaled_domain = image_domain_module.ScaledDomain(self.scale)
+        self.assertIsInstance(scaled_domain, image_domain_module.ScaledDomain)
+
+    def test_send_and_receive(self):
+        """Test send and receive"""
+        scaled_domain = image_domain_module.ScaledDomain(self.scale)
+        scaled_image = scaled_domain.send(self.image)
+        torch.testing.assert_close(scaled_image, self.image / self.scale)
+        received_image = scaled_domain.receive(scaled_image)
+        torch.testing.assert_close(received_image, self.image)
+
+
+class TestStandardizedDomain(unittest.TestCase):
+    """Tests for bdpy.dl.torch.domain.image_domain.StandardizedDomain"""
+    def setUp(self):
+        self.params = [
+            {"center": 0.2, "scale": 0.5, "dim": 0},
+            {"center": np.array([0.2, 0.3, 0.4]), "scale": np.array([0.5, 0.6, 0.7]), "dim": 1},
+            {"center": np.array([[0.2, 0.3], [0.4, 0.5]]), "scale": np.array([[0.5, 0.6], [0.7, 0.8]]), "dim": 2},
+            {"center": np.random.randn(3, 4, 4) * 0.1, "scale": np.random.randn(3, 4, 4) * 0.1, "dim": 3},
+        ]
+        self.image = torch.from_numpy(np.random.randn(1, 3, 4, 4))
+
+    def test_instantiation(self):
+        """Test instantiation."""
+        for p in self.params:
+            if p["dim"] != 2:
+                standardized_domain = image_domain_module.StandardizedDomain(p["center"], p["scale"])
+                self.assertIsInstance(standardized_domain, image_domain_module.StandardizedDomain)
+            else:
+                with self.assertRaises(ValueError):
+                    image_domain_module.StandardizedDomain(p["center"], p["scale"])
 
         # Fails when the center is neither 1-dimensional nor 3-dimensional
         with self.assertRaises(ValueError):
-            iamge_domain_module.AffineDomain(self.center2d, self.scale0d)
+            image_domain_module.StandardizedDomain(self.params[2]["center"], self.params[0]["scale"])
 
         # Fails when the scale is neither 1-dimensional nor 3-dimensional
         with self.assertRaises(ValueError):
-            iamge_domain_module.AffineDomain(self.center0d, self.scale2d)
-    
+            image_domain_module.StandardizedDomain(self.params[0]["center"], self.params[2]["scale"])
+
     def test_send_and_receive(self):
         """Test send and receive"""
-        # when 0d
-        affine_domain = iamge_domain_module.AffineDomain(self.center0d, self.scale0d)
-        transformed_image = affine_domain.send(self.image)
-        center0d = torch.from_numpy(np.array([self.center0d])[np.newaxis, np.newaxis, np.newaxis])
-        scale0d = torch.from_numpy(np.array([self.scale0d])[np.newaxis, np.newaxis, np.newaxis])
-        expected_transformed_image = (self.image + center0d) / self.scale0d
-        torch.testing.assert_close(transformed_image, expected_transformed_image)
-        received_image = affine_domain.receive(transformed_image)
-        expected_received_image = expected_transformed_image * scale0d - center0d
-        torch.testing.assert_close(received_image, expected_received_image)
+        ## Case: 0d
+        center, scale = self.params[0]["center"], self.params[0]["scale"]
+        center_pt = torch.from_numpy(np.array([center])[np.newaxis, np.newaxis, np.newaxis])
+        scale_pt = torch.from_numpy(np.array([scale])[np.newaxis, np.newaxis, np.newaxis])
+        standardized_domain = image_domain_module.StandardizedDomain(center, scale)
+        destandardized_image = standardized_domain.send(self.image)
+        expected_destandardized_image = self.image * scale_pt + center_pt
+        torch.testing.assert_close(destandardized_image, expected_destandardized_image)
+        standardized_image = standardized_domain.receive(destandardized_image)
+        torch.testing.assert_close(standardized_image, self.image)
 
-        # when 1d
-        affine_domain = iamge_domain_module.AffineDomain(self.center1d, self.scale1d)
-        transformed_image = affine_domain.send(self.image)
-        center1d = self.center1d[np.newaxis, :, np.newaxis, np.newaxis]
-        scale1d = self.scale1d[np.newaxis, :, np.newaxis, np.newaxis]
-        expected_transformed_image = (self.image + center1d) / scale1d
-        torch.testing.assert_close(transformed_image, expected_transformed_image)
-        received_image = affine_domain.receive(transformed_image)
-        expected_received_image = expected_transformed_image * scale1d - center1d
-        torch.testing.assert_close(received_image, expected_received_image)
+        ## Case: 1d
+        center, scale = self.params[1]["center"], self.params[1]["scale"]
+        center_pt = torch.from_numpy(center[np.newaxis, :, np.newaxis, np.newaxis])
+        scale_pt = torch.from_numpy(scale[np.newaxis, :, np.newaxis, np.newaxis])
+        standardized_domain = image_domain_module.StandardizedDomain(center, scale)
+        destandardized_image = standardized_domain.send(self.image)
+        expected_destandardized_image = self.image * scale_pt + center_pt
+        torch.testing.assert_close(destandardized_image, expected_destandardized_image)
+        standardized_image = standardized_domain.receive(destandardized_image)
+        torch.testing.assert_close(standardized_image, self.image)
 
-        # when 3d
-        affine_domain = iamge_domain_module.AffineDomain(self.center3d, self.scale3d)
-        transformed_image = affine_domain.send(self.image)
-        center3d = self.center3d[np.newaxis]
-        scale3d = self.scale3d[np.newaxis]
-        expected_transformed_image = (self.image + center3d) / scale3d
-        torch.testing.assert_close(transformed_image, expected_transformed_image)
-        received_image = affine_domain.receive(transformed_image)
-        expected_received_image = expected_transformed_image * scale3d - center3d
-        torch.testing.assert_close(received_image, expected_received_image)
+        ## Case: 3d
+        center, scale = self.params[3]["center"], self.params[3]["scale"]
+        center_pt = torch.from_numpy(center[np.newaxis])
+        scale_pt = torch.from_numpy(scale[np.newaxis])
+        standardized_domain = image_domain_module.StandardizedDomain(center, scale)
+        destandardized_image = standardized_domain.send(self.image)
+        expected_destandardized_image = self.image * scale_pt + center_pt
+        torch.testing.assert_close(destandardized_image, expected_destandardized_image)
+        standardized_image = standardized_domain.receive(destandardized_image)
+        torch.testing.assert_close(standardized_image, self.image)
 
 
 class TestRGBDomain(unittest.TestCase):
@@ -87,13 +118,13 @@ class TestRGBDomain(unittest.TestCase):
 
     def test_send(self):
         """Test send"""
-        bgr_domain = iamge_domain_module.BGRDomain()
+        bgr_domain = image_domain_module.BGRDomain()
         transformed_image = bgr_domain.send(self.bgr_image)
         torch.testing.assert_close(transformed_image, self.rgb_image)
-    
+
     def test_receive(self):
         """Tests receive"""
-        bgr_domain = iamge_domain_module.BGRDomain()
+        bgr_domain = image_domain_module.BGRDomain()
         received_image = bgr_domain.receive(self.rgb_image)
         torch.testing.assert_close(received_image, self.bgr_image)
 
@@ -106,13 +137,13 @@ class TestPILDomainWithExplicitCrop(unittest.TestCase):
 
     def test_send(self):
         """Test send"""
-        pdwe_domain = iamge_domain_module.PILDomainWithExplicitCrop()
+        pdwe_domain = image_domain_module.PILDomainWithExplicitCrop()
         transformed_image = pdwe_domain.send(self.image)
         torch.testing.assert_close(transformed_image, self.expected_transformed_image)
 
     def test_receive(self):
         """Tests receive"""
-        pdwe_domain = iamge_domain_module.PILDomainWithExplicitCrop()
+        pdwe_domain = image_domain_module.PILDomainWithExplicitCrop()
         with warnings.catch_warnings(record=True) as w:
             received_image = pdwe_domain.receive(self.expected_transformed_image)
         self.assertTrue(any(isinstance(warn.message, RuntimeWarning) for warn in w))
@@ -127,14 +158,14 @@ class TestFixedResolutionDomain(unittest.TestCase):
 
     def test_send(self):
         """Test send"""
-        fr_domain = iamge_domain_module.FixedResolutionDomain((16, 16))
+        fr_domain = image_domain_module.FixedResolutionDomain((16, 16))
         with self.assertRaises(RuntimeError):
             fr_domain.send(self.image)
 
     def test_receive(self):
         """Tests receive"""
-        fr_domain = iamge_domain_module.FixedResolutionDomain((16, 16))
-        
+        fr_domain = image_domain_module.FixedResolutionDomain((16, 16))
+
         received_image = fr_domain.receive(self.image)
         self.assertEqual(received_image.size(), self.expected_received_image_size)
 


### PR DESCRIPTION
Replace AffineDomain with StandardizedDomain and ScaledDomain to enhance the image processing API. This change deprecates AffineDomain and provides clearer alternatives for standardization and scaling of images.

## Breaking changes in API
- `AffineDomain` is now deprecated and will raise `RuntimeError` when it is instantiated.
- `StandardizedDomain` and `ScaledDomain` are introduced as an alternative to the confusing `AffineDomain`