### PR TITLE
Fix problematic behavior of optimizer/scheduler in FeatureInversionTask

### DIFF
--- a/bdpy/recon/torch/modules/__init__.py
+++ b/bdpy/recon/torch/modules/__init__.py
@@ -2,3 +2,4 @@ from .encoder import build_encoder, BaseEncoder
 from .generator import build_generator, BaseGenerator
 from .latent import ArbitraryLatent, BaseLatent
 from .critic import TargetNormalizedMSE, BaseCritic
+from .optimizer import build_optimizer_factory, build_scheduler_factory

--- a/bdpy/recon/torch/modules/optimizer.py
+++ b/bdpy/recon/torch/modules/optimizer.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import Callable, Iterator, TYPE_CHECKING
+from functools import partial
+from itertools import chain
+
+if TYPE_CHECKING:
+    from torch.nn import Parameter
+    import torch.optim as optim
+    from ..modules import BaseGenerator, BaseLatent
+
+    _OptimizerFactoryType = Callable[[BaseGenerator, BaseLatent], optim.Optimizer]
+    _SchedulerFactoryType = Callable[[optim.Optimizer], optim.lr_scheduler.LRScheduler]
+    _GetParamsFnType = Callable[[BaseGenerator, BaseLatent], Iterator[Parameter]]
+
+
+def build_optimizer_factory(
+    optimizer_class: type[optim.Optimizer],
+    *,
+    get_params_fn: _GetParamsFnType | None = None,
+    **kwargs
+) -> _OptimizerFactoryType:
+    """Build an optimizer factory.
+
+    Parameters
+    ----------
+    optimizer_class : type
+        Optimizer class.
+    get_params_fn : Callable[[BaseGenerator, BaseLatent], Iterator[Parameter]] | None
+        Custom function to get parameters from the generator and the latent.
+        If None, it uses `chain(generator.parameters(), latent.parameters())`.
+    kwargs : dict
+        Keyword arguments for the optimizer.
+
+    Returns
+    -------
+    Callable[[BaseGenerator, BaseLatent], optim.Optimizer]
+        Optimizer factory.
+
+    Examples
+    --------
+    >>> from torch.optim import Adam
+    >>> from bdpy.recon.torch.modules import build_optimizer_factory
+    >>> optimizer_factory = build_optimizer_factory(Adam, lr=1e-3)
+    >>> optimizer = optimizer_factory(generator, latent)
+    """
+    if get_params_fn is None:
+        get_params_fn = lambda generator, latent: chain(
+            generator.parameters(), latent.parameters()
+        )
+
+    def init_fn(generator: BaseGenerator, latent: BaseLatent) -> optim.Optimizer:
+        return optimizer_class(get_params_fn(generator, latent), **kwargs)
+
+    return init_fn
+
+
+def build_scheduler_factory(
+    scheduler_class: type[optim.lr_scheduler.LRScheduler], **kwargs
+) -> _SchedulerFactoryType:
+    """Build a scheduler factory.
+
+    Parameters
+    ----------
+    scheduler_class : type
+        Scheduler class.
+    kwargs : dict
+        Keyword arguments for the scheduler.
+
+    Returns
+    -------
+    Callable[[optim.Optimizer], optim.lr_scheduler.LRScheduler]
+        Scheduler factory.
+
+    Examples
+    --------
+    >>> from torch.optim.lr_scheduler import StepLR
+    >>> from bdpy.recon.torch.modules import build_scheduler_factory
+    >>> scheduler_factory = build_scheduler_factory(StepLR, step_size=100, gamma=0.1)
+    >>> scheduler = scheduler_factory(optimizer)
+    """
+    return partial(scheduler_class, **kwargs)

--- a/tests/recon/torch/modules/test_optimizer.py
+++ b/tests/recon/torch/modules/test_optimizer.py
@@ -1,0 +1,113 @@
+"""Tests for bdpy.recon.torch.modules.optimizer"""
+
+from __future__ import annotations
+
+import unittest
+
+from functools import partial
+import numpy as np
+import torch.nn as nn
+import torch.optim as optim
+from bdpy.recon.torch.modules import build_generator, ArbitraryLatent
+from bdpy.recon.torch.modules import build_optimizer_factory, build_scheduler_factory
+
+
+class MLP(nn.Module):
+    def __init__(self, in_dim, out_dim):
+        super().__init__()
+        self.fc = nn.Linear(in_dim, out_dim)
+
+    def forward(self, x):
+        return self.fc(x)
+
+
+class TestBuildOptimizerFactory(unittest.TestCase):
+    """Tests for bdpy.recon.torch.modules.optimizer.build_optimizer_factory"""
+
+    def test_build_optimizer_factory(self):
+        generator = build_generator(MLP(64, 10))
+        latent = ArbitraryLatent(
+            (1, 64), init_fn=partial(nn.init.normal_, mean=0, std=1)
+        )
+        optimizer_factory = build_optimizer_factory(optim.SGD, lr=0.1)
+        optimizer = optimizer_factory(generator, latent)
+        self.assertIsInstance(
+            optimizer,
+            optim.SGD,
+            msg="optimizer_factory should return an instance of optim.Optimizer",
+        )
+
+        latent.reset_states()
+        generator.reset_states()
+        latent_prev = latent().detach().clone().numpy()
+        optimizer.zero_grad()
+        output = generator(latent())
+        loss = output.sum()
+        loss.backward()
+        latent_next_expected = (
+            latent_prev - 0.1 * latent().grad.detach().clone().numpy()
+        )
+        optimizer.step()
+        latent_next = latent().detach().clone().numpy()
+        np.testing.assert_allclose(
+            latent_next,
+            latent_next_expected,
+            rtol=1e-6,
+            err_msg="Optimizer does not update the latent variable correctly.",
+        )
+
+        # check if all the frozen generator's gradients are None
+        generator_grad = [p.grad for p in generator.parameters()]
+        self.assertTrue(
+            all([g is None for g in generator_grad]),
+            msg="Frozen generator's gradients should be None after the optimizer step.",
+        )
+
+
+class TestBuildSchedulerFactory(unittest.TestCase):
+    """Tests for bdpy.recon.torch.modules.optimizer.build_scheduler_factory"""
+
+    def test_build_scheduler_factory(self):
+        generator = build_generator(MLP(64, 10))
+        latent = ArbitraryLatent(
+            (1, 64), init_fn=partial(nn.init.normal_, mean=0, std=1)
+        )
+        optimizer_factory = build_optimizer_factory(optim.SGD, lr=0.1)
+        scheduler_factory = build_scheduler_factory(
+            optim.lr_scheduler.StepLR, step_size=1, gamma=0.1
+        )
+        optimizer = optimizer_factory(generator, latent)
+        scheduler = scheduler_factory(optimizer)
+        self.assertIsInstance(
+            scheduler,
+            optim.lr_scheduler.StepLR,
+            msg="Scheduler factory should return an instance of optim.lr_scheduler.LRScheduler",
+        )
+
+        latent.reset_states()
+        generator.reset_states()
+        optimizer.zero_grad()
+        output = generator(latent())
+        loss = output.sum()
+        loss.backward()
+        optimizer.step()
+        scheduler.step()
+        self.assertEqual(
+            optimizer.param_groups[0]["lr"],
+            0.1 * 0.1,
+            "Scheduler does not update the learning rate correctly.",
+        )
+
+        # check if reference to the optimizer is kept during re-initialization
+        for _ in range(10):
+            optimizer = optimizer_factory(generator, latent)
+            scheduler = scheduler_factory(optimizer)
+        else:
+            self.assertTrue(
+                scheduler.optimizer is optimizer,
+                "Scheduler should keep the reference to the optimizer during re-initialization.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/recon/torch/task/test_inversion.py
+++ b/tests/recon/torch/task/test_inversion.py
@@ -171,7 +171,6 @@ class TestFeatureInversionTask(unittest.TestCase):
         self.generator = generator_module.DNNGenerator(LinearGenerator())
         self.latent = DummyNNModuleLatent(self.init_latent.clone())
         self.critic = critic_module.MSE()
-        # self.optimizer = optim.SGD([self.latent.latent], lr=0.1)
         self.optimizer_factory = optimizer_module.build_optimizer_factory(optim.SGD, lr=0.1)
         self.callbacks = DummyFeatureInversionCallback()
 


### PR DESCRIPTION
## Problem

Current implementation of `FeatureInversionTask` has several limitations/problems in the use of optimizer/scheduler. Here are the concrete examples:

### Initialization using param_groups works only one time

```python
optimizer = optim.SGD([
  {"params": latent.parameters(), "lr": latent_lr},
  {"params": generator.parameters(), "lr" generator_lr},
], lr=base_lr)
task = FeatureInversionTask(encoder, generator, latent, critic, optimizer, num_iterations=100)
reconstructed = task(target_features)  # uses latent_lr for a latent module and generator_lr for a generator module
task.reset_states()
reconstructed_2 = task(target_features)  # uses base_lr for both latent module and generator module
```

### Cannot use a learning rate scheduler

```python
optimizer = optim.SGD(latent.parameters(), lr=0.01)
scheduler = ExponentialLR(optimizer, gamma=0.9)
task = FeatureInversionTask(encoder, generator, latent, critic, optimizer, scheduler=scheduler, num_iterations=100)
task.reset_states()
reconstructed = task(target_features)  # learning rate scheduler does not work properly
```

## Cause
The cause of the problem is in the implementation of `reset_states()`:

https://github.com/KamitaniLab/bdpy/blob/9ffe7bc3f88757e11fb494223dbe6ffd353027fb/bdpy/recon/torch/task/inversion.py#L216-L226

Originally this method was implemented based on the following assumptions:

- We can dynamically provide a consistent way of re-initializing optimizers only from their instances (L220-226)
- Learning rate schedulers are not needed to be re-initialized

In reality, neither of these assumptions were true. In addition, since optimizers generally have dependencies on generator and latent instances, and learning rate schedulers have dependencies on optimizer instances, when any of these dependencies are re-instantiated, the references need to be replaced accordingly.

## Solution

Instead of receiving the instances of the optimizer and learning rate scheduler themselves, FeatureInversionTask receives the factory method for creating instances. Following is the example use of the newly designed API:

```python
encoder = build_encoder(...)
generator = build_generator(...)
latent = ArbitraryLatent(...)
critic = TargetNormalizedMSE(...)

optimizer_factory = build_optimizer_factory(
    SGD,
    get_params_fn=lambda generator, latent: [
        {"params": latent.parameters(), "lr": latent_lr},
        {"params": generator.parameters(), "lr" generator_lr},
    ],
    lr=base_lr, momentum=0.9
)
scheduler_factory = build_scheduler_factory(ExponentialLR, gamma=0.9)

task = FeatureInversionTask(
    encoder, generator, latent, critic,
    optimizer_factory, scheduler_factory,
    num_iterations=100,
)
reconstructed = task(target_features)

...
## In reset_states() of FeatureInversionTask
optimizer = optimizer_factory(generator, latent)
scheduler = scheduler_factory(optimizer)
```

## Breaking changes in API

- `FeatureInversionTask` takes `optimizer_factory: (BaseGenerator, BaseLatent) -> Optimizer` instead of `optimizer: Optimizer` as an input argument
- `FeatureInversionTask` takes `scheduler_factory: Optimizer -> LRScheduler` instead of `scheduler: LRScheduler` as an input argument
