### PR TITLE
Hotfix: pin pytest-github-actions-annotate-failures to version 0.2.0 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest pytest-cov pytest-github-actions-annotate-failures
+        python -m pip install pytest pytest-cov pytest-github-actions-annotate-failures==0.2.0
         pip install .[dev]
 
     # https://stackoverflow.com/questions/985876/tee-and-exit-status


### PR DESCRIPTION
This PR is a temporary hotfix to ensure that CI works without problems. Currently, CI in the repository is not working properly (probably) due to an error caused by the latest version of pytest-github-actions-annotate-failures. We expect that future revisions to this plugin will resolve the issue, but for the time being we have made a change to fix the plugin to a previous version so that CI can be used without any problems.