### PR TITLE
Update openneuro

### DIFF
--- a/bdpy/opendata/openneuro.py
+++ b/bdpy/opendata/openneuro.py
@@ -1,14 +1,93 @@
-import os
+import os, sys
 import re
 import shutil
 import json
 from glob import glob
-
+import traceback
 from bdpy import makedir_ifnot
+import subprocess
 
 
-def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./', bids_dir='bids', fmap=False, dry_run=False):
-    '''Create BIDS dataset for OpenNeuro.'''
+def show_collated_data(src, source_type='bids_daily', root_dir='./', bids_dir='bids', fmap=False):
+    """
+    Check existing file counts by parsing daily experimetal directories based on Yaml.
+    :param src: Structured data information loaded from yaml file.
+        - Based on the daily experiment data organization.
+    :param source_type: Source data type. Currently only 'bids_daily' is supported.
+    :param root_dir: Root directory of the daily experiment data
+    :param bids_dir: BIDS directory name under each experiment date directory (e.g., 'bids', 'bids_fmap', etc.)
+    :param fmap: Whether to check field map data
+    """
+    if not source_type == 'bids_daily':
+        raise NotImplementedError('Source type %s not supported.' % source_type)
+    
+    for subject, sub_data in src.items():
+        print('----------------------------------------')
+        print(subject)
+
+        # Reference anatomy
+        src_anat = os.path.join(root_dir, sub_data['anat'])
+        if not os.path.exists(src_anat):
+            raise RuntimeError('Anatomy file not found: %s' % src_anat)
+
+        # Functionals
+        tasks = sub_data['func']
+        for task, srcdata_dict in tasks.items():
+            print('--------------------')
+            print('{} includes {} experimental dates'.format(task, len(srcdata_dict.keys())))
+            print('')
+
+            # Prepare source data
+            ses_num = 0
+            run_num = 0
+            for src_name, src_info in srcdata_dict.items():
+                src_bids_path = os.path.join(root_dir, src_name, bids_dir)
+                if not os.path.exists(src_bids_path):
+                    raise RuntimeError('Not found BIDS directory: %s' % src_bids_path)
+                else:
+                    print("Parse BIDS directory:", src_bids_path)
+                
+                sessions = __parse_bids_dir(src_bids_path, data_info=src_info)
+                ses_num += len(sessions)
+                for ses in sessions:
+                    run_num += len(ses['functionals'])
+
+                    src_inplane = ses['inplane']
+                    if not os.path.exists(src_inplane):
+                        raise RuntimeError('Inplane image found: %s' % src_inplane)
+
+                    if fmap:
+                        src_fmap_dir = os.path.join(os.path.dirname(os.path.dirname(ses['inplane'])), 'fmap')
+                        fmap_files = glob(os.path.join(src_fmap_dir, '*.nii.gz'))
+                        if not fmap_files:
+                            raise RuntimeError('No field map files found in %s' % src_fmap_dir)
+
+            print('Total sessions: %d' % ses_num)
+            print('Total runs: %d' % run_num)
+            print('')
+
+        return None
+
+
+def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./', bids_dir='bids', 
+             anatomy=True, inplane=True, fmap=False, functionals=True, run_deface=False,
+             dry_run=False):
+    '''
+    Create BIDS dataset for OpenNeuro.
+    :param src: Structured data information loaded from yaml file.
+        - Based on the daily experiment data organization.
+    :param source_type: Source data type. Currently only 'bids_daily' is supported.
+    :param output_dir: Output directory for costructed BIDS dataset.
+    :param root_dir: Root directory of the input daily experiment data
+    :param bids_dir: BIDS directory name under each experiment date directory (e.g., 'bids', 'bids_fmap', etc.)
+    :param anatomy: Whether to convert anatomy data
+    :param inplane: Whether to convert inplane T2 data
+    :param fmap: Whether to convert field map data
+    :param functionals: Whether to convert functional data
+    :param run_deface: Whether to run pydeface for anatomy data
+        ! If pydeface doesn't work, set it to False.
+    :param dry_run: If True, only print the operations without actual file copying
+    '''
 
     if not source_type == 'bids_daily':
         raise NotImplementedError('Source type %s not supported.' % source_type)
@@ -52,16 +131,24 @@ def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./'
         trg_anat_raw = os.path.join(trg_anat_dir, '%s_ses-anatomy_T1w_raw.nii.gz' % subject)
         trg_anat_defaced = os.path.join(trg_anat_dir, '%s_ses-anatomy_T1w.nii.gz' % subject)
         __create_dir(trg_anat_dir)
-        if not dry_run and not os.path.exists(trg_anat_defaced):
-            ext = os.path.splitext(src_anat)[1]
-            if ext == '.gz':
-                shutil.copy2(src_anat, trg_anat_raw)  # FIXME: convert to nii.gz
-            else:
-                convert_command = 'mri_convert %s %s' % (src_anat, trg_anat_raw)
-                os.system(convert_command)
-            deface_command = 'pydeface %s --outfile %s' % (trg_anat_raw, trg_anat_defaced)
-            os.system(deface_command)
-            os.remove(trg_anat_raw)
+
+        if anatomy:
+            if not dry_run and not os.path.exists(trg_anat_defaced):
+                ext = os.path.splitext(src_anat)[1]
+                if ext == '.gz':
+                    shutil.copy2(src_anat, trg_anat_raw)  # FIXME: convert to nii.gz
+                else:
+                    convert_command = 'mri_convert %s %s' % (src_anat, trg_anat_raw)
+                    result = subprocess.run(convert_command.split(" "), capture_output=True, text=True)
+                    if result.returncode != 0:
+                        raise RuntimeError(f"{result.stdout}")
+                    
+                # Due to environment-dependent issues, it is possible to specify whether to run deface.
+                if run_deface:
+                    deface_command = 'pydeface %s --outfile %s' % (trg_anat_raw, trg_anat_defaced)
+                    result = subprocess.run(deface_command.split(" "), capture_output=True, text=True)
+                    if result.returncode != 0:
+                        raise RuntimeError(f"{result.stdout}")
 
         # Functionals
         tasks = sub_data['func']
@@ -75,25 +162,17 @@ def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./'
         print('%d task(s)' % len(tasks))
         print('')
 
-        for task, srcdata in tasks.items():
+        for task, srcdata_dict in tasks.items():
             print('--------------------')
-            print(task)
-            print('%d data' % len(srcdata))
+            print('{} includes {} data'.format(task, len(srcdata_dict.keys())))
             print('')
 
+            # Prepare source data
             task_sessions = []
 
-            for src in srcdata:
-                if isinstance(src, dict):
-                    src_name = list(src.keys())[0]
-                    src_info = src[src_name]
-                else:
-                    src_name = src
-                    src_info = None
-
+            for src_name, src_info in srcdata_dict.items():
                 src_bids_path = os.path.join(root_dir, src_name, bids_dir)
-
-                print(src_name)
+                print(src_bids_path)
 
                 if not os.path.isdir(src_bids_path):
                     raise RuntimeError('Invalid BIDS directory: %s' % src_bids_path)
@@ -117,24 +196,29 @@ def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./'
                     __create_dir(os.path.join(session_dir, 'anat'))
                     __create_dir(os.path.join(session_dir, 'func'))
 
-                # T2 inplane image
                 src_inplane = ses['inplane']
-                if not src_inplane is None:
-                    rename_table = {
-                        os.path.basename(src_inplane).split('_')[0]: subject,       # SUbject ID
-                        os.path.basename(src_inplane).split('_')[1]: session_label, # Session label
-                    }
-                    trg_inplane = os.path.join(session_dir, 'anat',
-                                               __rename_file(os.path.basename(src_inplane).split('.')[0] + '.nii.gz',
-                                                             rename=rename_table))
-                    print('Copying\n  from: %s\n  to: %s' % (src_inplane, trg_inplane))
-                    if not dry_run and not os.path.exists(trg_inplane):
-                        ext = os.path.splitext(src_inplane)[1]
-                        if ext == '.gz':
-                            shutil.copy2(src_inplane, trg_inplane)
-                        else:
-                            convert_command = 'mri_convert %s %s' % (src_inplane, trg_inplane)
-                            os.system(convert_command)
+                rename_table = {
+                    os.path.basename(src_inplane).split('_')[0]: subject,       # SUbject ID
+                    os.path.basename(src_inplane).split('_')[1]: session_label, # Session label
+                }
+
+                # T2 inplane image
+                if inplane:
+                    src_inplane = ses['inplane']
+                    if not src_inplane is None:
+                        trg_inplane = os.path.join(session_dir, 'anat',
+                                                __rename_file(os.path.basename(src_inplane).split('.')[0] + '.nii.gz',
+                                                                rename=rename_table))
+                        print('Copying\n  from: %s\n  to: %s' % (src_inplane, trg_inplane))
+                        if not dry_run and not os.path.exists(trg_inplane):
+                            ext = os.path.splitext(src_inplane)[1]
+                            if ext == '.gz':
+                                shutil.copy2(src_inplane, trg_inplane)
+                            else:
+                                convert_command = 'mri_convert %s %s' % (src_inplane, trg_inplane)
+                                result = subprocess.run(convert_command.split(" "), capture_output=True, text=True)
+                                if result.returncode != 0:
+                                    raise RuntimeError(f"{result.stdout}")
 
                 # Field map
                 if fmap:
@@ -149,14 +233,18 @@ def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./'
                             trg_fmap_dir,
                             __rename_file(os.path.basename(src_f).split('.')[0] + '.nii.gz', rename=rename_table)
                         )
-                        print('Copying\n  from: %s\n  to: %s' % (src_f, trg_f))
-                        if not dry_run and not os.path.exists(trg_f):
+                        if dry_run:
+                            print('Copying\n  from: %s\n  to: %s' % (src_f, trg_f))
+                        elif not os.path.exists(trg_f):
+                            print('Copying\n  from: %s\n  to: %s' % (src_f, trg_f))
                             ext = os.path.splitext(src_f)[1]
                             if ext == '.gz':
                                 shutil.copy2(src_f, trg_f)
                             else:
                                 convert_command = 'mri_convert %s %s' % (src_f, trg_f)
-                                os.system(convert_command)
+                                result = subprocess.run(convert_command.split(" "), capture_output=True, text=True)
+                                if result.returncode != 0:
+                                    raise RuntimeError(f"{result.stdout}")
 
                     for f in glob(os.path.join(src_fmap_dir, '*.json')):
                         src_f = f
@@ -164,62 +252,75 @@ def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./'
                             trg_fmap_dir,
                             __rename_file(os.path.basename(src_f).split('.')[0] + '.json', rename=rename_table)
                         )
-                        print('Copying\n  from: %s\n  to: %s' % (src_f, trg_f))
-                        if not dry_run and not os.path.exists(trg_f):
+                        if dry_run:
+                            print('Copying\n  from: %s\n  to: %s' % (src_f, trg_f))
+                        elif not os.path.exists(trg_f):
+                            print('Copying\n  from: %s\n  to: %s' % (src_f, trg_f))
                             with open(src_f, 'r') as f:
                                 js = json.load(f)
                             if 'IntendedFor' in js:
-                                fs = [
-                                    __rename_file(f, rename=rename_table)
-                                    for f in js['IntendedFor']
-                                ]
+                                fs = []
+                                for fi, f in enumerate(js['IntendedFor']):
+                                    # # IntendedFor includes the original number of runs, so when using exclude runs, you need to reduce the number.
+                                    if fi < len(ses['functionals']): 
+                                        f = __rename_file(f, rename=rename_table)
+                                        fs.append(f)
                                 js['IntendedFor'] = fs
                             with open(trg_f, 'w') as f:
                                 json.dump(js, f, indent=4)
 
                 # Functionals
-                for j, run in enumerate(ses['functionals']):
-                    src_bold = run['bold']
-                    src_bold_json = run['bold_json']
-                    src_event = run['event']
+                if functionals:
+                    for j, run in enumerate(ses['functionals']):
+                        src_bold = run['bold']
+                        src_bold_json = run['bold_json']
+                        src_event = run['event']
 
-                    # File renaming
-                    rename_table = {
-                        os.path.basename(src_bold).split('_')[0]: subject,       # SUbject ID
-                        os.path.basename(src_bold).split('_')[1]: session_label, # Session label
-                                   }
+                        # File renaming
+                        rename_table = {
+                            os.path.basename(src_bold).split('_')[0]: subject,       # SUbject ID
+                            os.path.basename(src_bold).split('_')[1]: session_label, # Session label
+                                    }
 
-                    # Fix run label
-                    run_label = re.match('.*_run-(\d+)_.*', os.path.basename(src_bold)).group(1)
-                    if (j + 1) != int(run_label):
-                        print('Fix run label: run-%s --> run-%02d' % (run_label, j + 1))
-                        rename_table.update({'run-%s' % run_label: 'run-%02d' % (j + 1)})
+                        # Fix run label
+                        run_label = re.match('.*_run-(\d+)_.*', os.path.basename(src_bold)).group(1)
+                        if (j + 1) != int(run_label):
+                            print('Fix run label: run-%s --> run-%02d' % (run_label, j + 1))
+                            rename_table.update({'run-%s' % run_label: 'run-%02d' % (j + 1)})
 
-                    trg_bold = os.path.join(session_dir, 'func',
-                                            __rename_file(os.path.basename(src_bold).split('.')[0] + '.nii.gz',
-                                                          rename=rename_table))
-                    trg_bold_json = os.path.join(session_dir, 'func',
-                                                 __rename_file(os.path.basename(src_bold_json), rename=rename_table))
-                    trg_event = os.path.join(session_dir, 'func',
-                                             __rename_file(os.path.basename(src_event), rename=rename_table))
+                        trg_bold = os.path.join(session_dir, 'func',
+                                                __rename_file(os.path.basename(src_bold).split('.')[0] + '.nii.gz',
+                                                            rename=rename_table))
+                        trg_bold_json = os.path.join(session_dir, 'func',
+                                                    __rename_file(os.path.basename(src_bold_json), rename=rename_table))
+                        trg_event = os.path.join(session_dir, 'func',
+                                                __rename_file(os.path.basename(src_event), rename=rename_table))
 
-                    print('Copying\n  from: %s\n  to: %s' % (src_bold, trg_bold))
-                    print('Copying\n  from: %s\n  to: %s' % (src_bold_json, trg_bold_json))
-                    print('Copying\n  from: %s\n  to: %s' % (src_event, trg_event))
-                    if not dry_run and not os.path.exists(trg_bold):
-                        ext = os.path.splitext(src_bold)[1]
-                        if ext == '.gz':
-                            shutil.copy2(src_bold, trg_bold)
-                        else:
-                            convert_command = 'mri_convert %s %s' % (src_bold, trg_bold)
-                            os.system(convert_command)
-                        shutil.copy2(src_bold_json, trg_bold_json)
-                        shutil.copy2(src_event, trg_event)
+                        print('Copying\n  from: %s\n  to: %s' % (src_bold, trg_bold))
+                        print('Copying\n  from: %s\n  to: %s' % (src_bold_json, trg_bold_json))
+                        print('Copying\n  from: %s\n  to: %s' % (src_event, trg_event))
+                        if not dry_run and not os.path.exists(trg_bold):
+                            ext = os.path.splitext(src_bold)[1]
+                            if ext == '.gz':
+                                shutil.copy2(src_bold, trg_bold)
+                            else:
+                                convert_command = 'mri_convert %s %s' % (src_bold, trg_bold)
+                                result = subprocess.run(convert_command.split(" "), capture_output=True, text=True)
+                                if result.returncode != 0:
+                                    raise RuntimeError(f"{result.stdout}")
+
+                            shutil.copy2(src_bold_json, trg_bold_json)
+                            shutil.copy2(src_event, trg_event)
 
     return None
 
 
 def __parse_bids_dir(dpath, data_info=None):
+    """
+    Parse BIDS directory for a specific experimental date and obtain session and file information.
+    :param dpath: BIDS directory path
+    :param data_info: Structured data information for a specific experimental date (sessions, excluded runs, etc.)
+    """
     print('BIDS directory: %s' % dpath)
 
     sub_dirs = glob(os.path.join(dpath, 'sub-*'))
@@ -232,22 +333,16 @@ def __parse_bids_dir(dpath, data_info=None):
     print('%d func session(s) found' % len(ses_dirs))
 
     sessions = []
+    unskip_session_counter = -1
     for i, ses_dir in enumerate(ses_dirs):
+        session_id = i + 1
 
         # Session selection
-        skip = False
         if (not data_info is None) and 'ses' in data_info:
-            if isinstance(data_info['ses'], int) and (i + 1) != data_info['ses']:
-                skip = True
-            elif isinstance(data_info['ses'], list) and (i + 1) not in data_info['ses']:
-                skip = True
-            elif isinstance(data_info['ses'], str) and (i + 1) not in [int(x) for x in data_info['ses'].split(',')]:
-                skip = True
-
-        if skip:
-            print('Skipping session %02d' % (i + 1))
-            continue
-
+            if session_id not in data_info['ses']:
+                print('Skipping session %02d' % (i + 1))
+                continue
+        
         # T2 inplane image
         inplane_file = __aggregate_mri_files(os.path.join(ses_dir, '../anat'), mri_filetype='nii') + __aggregate_mri_files(os.path.join(ses_dir, '../anat'), mri_filetype='nii.gz')
         if len(inplane_file) != 1:
@@ -256,30 +351,26 @@ def __parse_bids_dir(dpath, data_info=None):
 
         # Functionals
         run_files = __aggregate_runs(ses_dir, mri_filetype='nii') + __aggregate_runs(ses_dir, mri_filetype='nii.gz')
-        print('Ses %02d: %d run(s) found' % (i + 1, len(run_files)))
+        print('Ses %02d: %d run(s) found' % (session_id, len(run_files)))
         #print(run_files)
 
         # Run selection
         run_files_keep = []
         if (not data_info is None) and 'discard_run' in data_info:
             for j, rf in enumerate(run_files):
-                skip_run = False
-                if isinstance(data_info['discard_run'], int) and (j + 1) == data_info['discard_run']:
-                    skip_run = True
-                elif isinstance(data_info['discard_run'], list) and (j + 1) in data_info['discard_run']:
-                    skip_run = True
-                elif isinstance(data_info['discard_run'], str) and (j + 1) in [int(x) for x in data_info['discard_run'].split(',')]:
-                    skip_run = True
-                if skip_run:
-                    print('Skipping run %02d' % (j + 1))
+                run_id = j + 1
+                if run_id in data_info["discard_run"][unskip_session_counter]:
+                    print("Discard run:", run_id)
                 else:
                     run_files_keep.append(rf)
         else:
             run_files_keep = run_files
 
+        print("Use %d run(s)" % (len(run_files_keep)))
 
         sessions.append({'inplane': inplane_file,
                          'functionals': run_files_keep})
+        unskip_session_counter += 1
 
     print('')
 
@@ -324,6 +415,7 @@ def __rename_file(fname, rename={}):
 
 
 def __create_dir(dirpath):
-    print('Creating %s' % dirpath)
-    makedir_ifnot(dirpath)
+    if not os.path.exists(dirpath):        
+        print('Creating %s' % dirpath)
+        os.makedirs(dirpath)
     return None

--- a/bdpy/opendata/openneuro.py
+++ b/bdpy/opendata/openneuro.py
@@ -333,14 +333,14 @@ def __parse_bids_dir(dpath, data_info=None):
     print('%d func session(s) found' % len(ses_dirs))
 
     sessions = []
-    unskip_session_counter = -1
+    unskip_session_counter = 0 # A correction counter to correspond to 'discard_run' when a session is skipped, such as "ses: [2,3]".
     for i, ses_dir in enumerate(ses_dirs):
         session_id = i + 1
 
         # Session selection
         if (not data_info is None) and 'ses' in data_info:
             if session_id not in data_info['ses']:
-                print('Skipping session %02d' % (i + 1))
+                print('Skipping session %02d' % (session_id))
                 continue
         
         # T2 inplane image
@@ -352,7 +352,6 @@ def __parse_bids_dir(dpath, data_info=None):
         # Functionals
         run_files = __aggregate_runs(ses_dir, mri_filetype='nii') + __aggregate_runs(ses_dir, mri_filetype='nii.gz')
         print('Ses %02d: %d run(s) found' % (session_id, len(run_files)))
-        #print(run_files)
 
         # Run selection
         run_files_keep = []


### PR DESCRIPTION
The following changes were made to openneuro.py.
1. The number of runs in the `IntendFor` parameter in `*phasediff.json`, which is copied when the fmap directory is created, must correctly correspond to the number of runs in the BIDS structure, so the number of runs has been adjusted when using `exclude_run`.
2. Added `show_collated_data` as a function to check whether the intended number of runs has been secured in the specified YAML file before creating the bids structure.
3. Added flags to allow makedata to be executed individually for anatomy, inplane, fmap, and functionals.
4. Fixed an error that occurred with `exclude_run` in `__parse_bids_dir` depending on the number of `ses`.
5. Temporary support for pydeface: Since `pydeface` command could not be executed in the current base environment (due to an improper installation of the etelemetry package), a conservative change was made to allow deface to be skipped. → Note that deface must currently be executed manually.
