### PR TITLE
chore: Update Ruff's linting rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,10 +96,10 @@ select = ["E", "F", "N", "D", "ANN", "B", "NPY", "RUF"]
 ignore = ["E501", "D213", "D203"]
 exclude = ["test"]
 
-[tool.ruff.extend-per-file-ignores]
+[tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 
 [tool.pylint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ only-include = ["bdpy"]
 [tool.ruff]
 select = ["E", "F", "N", "D", "ANN", "B", "NPY", "RUF"]
 ignore = ["E501", "D213", "D203"]
-exclude = ["test"]
+exclude = ["tests"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ only-include = ["bdpy"]
 only-include = ["bdpy"]
 
 [tool.ruff]
-select = ["E", "F", "N", "D", "ANN", "B", "NPY", "RUF"]
+select = ["E", "F", "I", "N", "D", "ANN", "B", "NPY", "RUF"]
 ignore = ["E501"]
 exclude = ["tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ only-include = ["bdpy"]
 
 [tool.ruff]
 select = ["E", "F", "N", "D", "ANN", "B", "NPY", "RUF"]
-ignore = ["E501", "ANN101", "D213", "D203"]
+ignore = ["E501", "D213", "D203"]
 exclude = ["test"]
 
 [tool.ruff.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ only-include = ["bdpy"]
 
 [tool.ruff]
 select = ["E", "F", "N", "D", "ANN", "B", "NPY", "RUF"]
-ignore = ["E501", "D213", "D203"]
+ignore = ["E501"]
 exclude = ["tests"]
 
 [tool.ruff.lint.extend-per-file-ignores]
@@ -101,6 +101,9 @@ exclude = ["tests"]
 
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.pylint]
 disable = "line-too-long"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,9 +92,11 @@ only-include = ["bdpy"]
 only-include = ["bdpy"]
 
 [tool.ruff]
+exclude = ["tests"]
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "N", "D", "ANN", "B", "NPY", "RUF"]
 ignore = ["E501"]
-exclude = ["tests"]
 
 [tool.ruff.lint.extend-per-file-ignores]
 "__init__.py" = ["F401"]


### PR DESCRIPTION
## Summary

Update Ruff configuration in \`pyproject.toml\` to align with the latest Ruff format and strengthen linting rules.

## Changes

- **Drop redundant ignores**:
  - Remove \`ANN101\` (removed in recent Ruff versions).
  - Remove \`D203\` and \`D213\` from \`ignore\` since they are automatically disabled by \`convention = "numpy"\` (no longer need to be listed explicitly).
- **Update configuration section headers**: Move \`select\` and \`ignore\` under \`[tool.ruff.lint]\`, and rename \`[tool.ruff.*]\` → \`[tool.ruff.lint.*]\` to conform to the current Ruff config schema.
- **Fix excluded directory name**: Change \`exclude = ["test"]\` → \`exclude = ["tests"]\` to match the actual directory name.
- **Adopt numpy docstring convention**: Add \`[tool.ruff.lint.pydocstyle]\` with \`convention = "numpy"\`.
- **Enable import sorting rule**: Add \`"I"\` to \`select\` to enforce import order checks.