### PR TITLE
Handle NaN values in Y normalization

### DIFF
--- a/bdpy/ml/learning.py
+++ b/bdpy/ml/learning.py
@@ -362,6 +362,7 @@ class ModelTraining(object):
                     y_norm = self.Y_normalize['std']
                 Y = (Y - y_mean) / y_norm
                 Y[np.isinf(Y)] = 0
+                Y[np.isnan(Y)] = 0
 
             if not self.Y_sort is None:
                 print('Sorting Y')


### PR DESCRIPTION
Since the results of Y normalization can contain not only `np.inf` but also `np.nan`, I added a process to replace them with 0.

Numpy operations have the following properties:
- 1/0 results in `np.inf` (dividing a non-zero value by 0)
- 0/0 results in `np.nan` (dividing 0 by 0)

Since this occurs immediately after `Y - y_mean`, the procedure should essentially be 0/0. However, a very small error in float32 results in an operation like 3.2e-25/0 instead of 0/0, resulting `np.inf` in most cases. This makes this problem difficult to notice.
In very rare cases, 0/0 occurs, resulting in `np.nan` feature values. In such cases, the weights `W` contain `np.nan` values. This causes `np.nan` values ​​to appear in the predicted values, causing problems when using the predicted values ​​for reconstruction, etc.