### PR TITLE
Fix string identity comparison in BrainData

### DIFF
--- a/bdpy/mri/fmriprep.py
+++ b/bdpy/mri/fmriprep.py
@@ -385,7 +385,7 @@ class BrainData(object):
 
     @property
     def xyz(self):
-        if self.__dtype is 'surface':
+        if self.__dtype == 'surface':
             raise NotImplementedError('Vertex xyz coordinates are not implemented yet.')
         return self.__xyz
 
@@ -395,7 +395,7 @@ class BrainData(object):
 
     @property
     def n_vertex(self):
-        if self.__dtype is not 'surface':
+        if self.__dtype != 'surface':
             raise TypeError('Not surface data.')
         return self.__n_vertex
 


### PR DESCRIPTION
Small PR replacing is / is not with == / != for string literal comparisons on BrainData.__dtype in bdpy/mri/fmriprep.py

Spun off from the discussion in the comment (https://github.com/KamitaniLab/bdpy/pull/116#issuecomment-4418377894).