### PR TITLE
docs: fix show_metadata example typo

### DIFF
--- a/docs/bdata_api_examples.md
+++ b/docs/bdata_api_examples.md
@@ -20,7 +20,7 @@
 #### Show data
 
     # Show 'key' and 'description' of metadata
-    bdata.show_meatadata()
+    bdata.show_metadata()
 
     # Get 'value' of the metadata specified by 'key'
     voxel_x = bdata.get_metadata('voxel_x', where='VoxelData')


### PR DESCRIPTION
Fixes #113

Changes:
- `bdata.show_meatadata()` -> `bdata.show_metadata()` in `docs/bdata_api_examples.md` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Verified no duplicate open PR was found for the referenced issue number(s) before opening this PR.
