### PR TITLE
Use tolerant assertions for floating-point tests

### DIFF
--- a/tests/evals/test_metrics.py
+++ b/tests/evals/test_metrics.py
@@ -18,9 +18,9 @@ class TestMetrics(unittest.TestCase):
             for i in range(n)
         ]])
 
-        self.assertTrue(np.allclose(
-            profile_correlation(x, y), r
-        ))
+        np.testing.assert_allclose(
+            profile_correlation(x, y), r, rtol=1e-12, atol=1e-12
+        )
         self.assertEqual(profile_correlation(x, y).shape, (1, n))
 
         # Multi-d array
@@ -34,9 +34,9 @@ class TestMetrics(unittest.TestCase):
         ]])
         r = r.reshape(1, 4, 3, 2)
 
-        self.assertTrue(np.allclose(
-            profile_correlation(x, y), r
-        ))
+        np.testing.assert_allclose(
+            profile_correlation(x, y), r, rtol=1e-12, atol=1e-12
+        )
         self.assertEqual(profile_correlation(x, y).shape, (1, 4, 3, 2))
 
     def test_pattern_correlation(self):
@@ -48,9 +48,9 @@ class TestMetrics(unittest.TestCase):
             for i in range(10)
         ])
 
-        self.assertTrue(np.allclose(
-            pattern_correlation(x, y), r
-        ))
+        np.testing.assert_allclose(
+            pattern_correlation(x, y), r, rtol=1e-12, atol=1e-12
+        )
         self.assertEqual(pattern_correlation(x, y).shape, (10,))
 
         # Multi-d array
@@ -63,26 +63,23 @@ class TestMetrics(unittest.TestCase):
             for i in range(10)
         ])
 
-        self.assertTrue(np.allclose(
-            pattern_correlation(x, y), r
-        ))
+        np.testing.assert_allclose(
+            pattern_correlation(x, y), r, rtol=1e-12, atol=1e-12
+        )
         self.assertEqual(pattern_correlation(x, y).shape, (10,))
 
     def test_2d(self):
         with open('tests/data/testdata-2d.pkl.gz', 'rb') as f:
             d = pickle.load(f)
-        self.assertTrue(np.allclose(
-            profile_correlation(d['x'], d['y']),
-            d['r_prof']
-        ))
-        self.assertTrue(np.allclose(
-            pattern_correlation(d['x'], d['y']),
-            d['r_patt']
-        ))
-        self.assertTrue(np.allclose(
-            pairwise_identification(d['x'], d['y']),
-            d['ident_acc']
-        ))
+        np.testing.assert_allclose(
+            profile_correlation(d['x'], d['y']), d['r_prof'], rtol=1e-12, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            pattern_correlation(d['x'], d['y']), d['r_patt'], rtol=1e-12, atol=1e-12
+        )
+        np.testing.assert_allclose(
+            pairwise_identification(d['x'], d['y']), d['ident_acc'], rtol=1e-12, atol=1e-12
+        )
 
     def test_2d_nan(self):
         with open('tests/data/testdata-2d-nan.pkl.gz', 'rb') as f:
@@ -91,14 +88,14 @@ class TestMetrics(unittest.TestCase):
         #     profile_correlation(d['x'], d['y']),
         #     d['r_prof']
         # ))
-        self.assertTrue(np.allclose(
+        np.testing.assert_allclose(
             pattern_correlation(d['x'], d['y'], remove_nan=True),
-            d['r_patt'],
-        ))
-        self.assertTrue(np.allclose(
+            d['r_patt'], rtol=1e-12, atol=1e-12
+        )
+        np.testing.assert_allclose(
             pairwise_identification(d['x'], d['y'], remove_nan=True),
-            d['ident_acc'],
-        ))
+            d['ident_acc'], rtol=1e-12, atol=1e-12
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/feature/test_feature.py
+++ b/tests/feature/test_feature.py
@@ -26,7 +26,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (channel-wise) + SD (all)
         feat_valid = ((feat - feat_mean_ch) / feat_std_all) * feat_std0 + feat_mean0
@@ -35,7 +35,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (all) + SD (channel-wise)
         feat_valid = ((feat - feat_mean_all) / feat_std_ch) * feat_std0 + feat_mean0
@@ -44,7 +44,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (all) + SD (all)
         feat_valid = ((feat - feat_mean_all) / feat_std_all) * feat_std0 + feat_mean0
@@ -53,7 +53,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (channel-wise) + SD (channel-wise), self-mean shift
         feat_valid = ((feat - feat_mean_ch) / feat_std_ch) * feat_std0 + feat_mean_ch
@@ -62,7 +62,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift='self', scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (channel-wise) + SD (channel-wise), self-mean shift and self-SD scale
         feat_valid = ((feat - feat_mean_ch) / feat_std_ch) * feat_std_ch + feat_mean_ch
@@ -71,7 +71,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift='self', scale='self',
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
     def test_normalize_feature_3d(self):
         feat = np.random.rand(64, 16, 16)
@@ -94,7 +94,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (channel-wise) + SD (all)
         feat_valid = ((feat - feat_mean_ch) / feat_std_all) * feat_std0 + feat_mean0
@@ -103,7 +103,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (all) + SD (channel-wise)
         feat_valid = ((feat - feat_mean_all) / feat_std_ch) * feat_std0 + feat_mean0
@@ -112,7 +112,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (all) + SD (all)
         feat_valid = ((feat - feat_mean_all) / feat_std_all) * feat_std0 + feat_mean0
@@ -121,7 +121,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift=feat_mean0, scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (channel-wise) + SD (channel-wise), self-mean shift
         feat_valid = ((feat - feat_mean_ch) / feat_std_ch) * feat_std0 + feat_mean_ch
@@ -130,7 +130,7 @@ class TestUtilFeature(unittest.TestCase):
                                       shift='self', scale=feat_std0,
                                       std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
         # Mean (channel-wise) + SD (channel-wise), self-mean shift and self-SD scale
         feat_valid = ((feat - feat_mean_ch) / feat_std_ch) * feat_std_ch + feat_mean_ch
@@ -146,7 +146,7 @@ class TestUtilFeature(unittest.TestCase):
                                       channel_wise_std=False,
                                       scale=feat_std0, std_ddof=1)
 
-        np.testing.assert_array_equal(feat_test, feat_valid)
+        np.testing.assert_allclose(feat_test, feat_valid, rtol=1e-12, atol=1e-12)
 
 
 if __name__ == '__main__':

--- a/tests/preproc/test_interface.py
+++ b/tests/preproc/test_interface.py
@@ -25,7 +25,7 @@ class TestPreprocessorInterface(unittest.TestCase):
         test_output_x, test_output_ind = interface.average_sample(
             x, group, verbose=True)
 
-        np.testing.assert_array_equal(test_output_x, exp_output_x)
+        np.testing.assert_allclose(test_output_x, exp_output_x, rtol=1e-12, atol=1e-12)
         np.testing.assert_array_equal(test_output_ind, exp_output_ind)
 
     @classmethod
@@ -43,7 +43,7 @@ class TestPreprocessorInterface(unittest.TestCase):
 
         test_output = interface.detrend_sample(x, group, verbose=True)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     @classmethod
     def test_detrend_sample_nokeepmean(cls):
@@ -59,7 +59,7 @@ class TestPreprocessorInterface(unittest.TestCase):
         test_output = interface.detrend_sample(
             x, group, keep_mean=False, verbose=True)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     @classmethod
     def test_normalize_sample(cls):
@@ -77,7 +77,7 @@ class TestPreprocessorInterface(unittest.TestCase):
 
         test_output = interface.normalize_sample(x, group, verbose=True)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     @classmethod
     def test_shift_sample_singlegroup(cls):

--- a/tests/recon/torch/modules/test_optimizer.py
+++ b/tests/recon/torch/modules/test_optimizer.py
@@ -53,6 +53,7 @@ class TestBuildOptimizerFactory(unittest.TestCase):
             latent_next,
             latent_next_expected,
             rtol=1e-6,
+            atol=1e-8,
             err_msg="Optimizer does not update the latent variable correctly.",
         )
 
@@ -92,10 +93,10 @@ class TestBuildSchedulerFactory(unittest.TestCase):
         loss.backward()
         optimizer.step()
         scheduler.step()
-        self.assertEqual(
+        self.assertAlmostEqual(
             optimizer.param_groups[0]["lr"],
             0.1 * 0.1,
-            "Scheduler does not update the learning rate correctly.",
+            msg="Scheduler does not update the learning rate correctly.",
         )
 
         # check if reference to the optimizer is kept during re-initialization

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -20,7 +20,7 @@ class TestStats(unittest.TestCase):
 
         test_output = bdst.corrcoef(x, y)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     def test_corrcoef_matrix_matrix_varcol(self):
         '''Test for corrcoef (matrix and matrix, var=col)'''
@@ -33,7 +33,7 @@ class TestStats(unittest.TestCase):
 
         test_output = bdst.corrcoef(x, y, var='col')
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     def test_corrcoef_vector_vector(self):
         '''Test for corrcoef (vector and vector)'''
@@ -45,7 +45,7 @@ class TestStats(unittest.TestCase):
 
         test_output = bdst.corrcoef(x, y)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     def test_corrcoef_hvector_hvector(self):
         '''Test for corrcoef (horizontal vector and horizontal vector)'''
@@ -57,7 +57,7 @@ class TestStats(unittest.TestCase):
 
         test_output = bdst.corrcoef(x, y)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     def test_corrcoef_vvector_vvector(self):
         '''Test for corrcoef (vertical vector and vertical vector)'''
@@ -69,7 +69,7 @@ class TestStats(unittest.TestCase):
 
         test_output = bdst.corrcoef(x, y)
 
-        np.testing.assert_array_equal(test_output, exp_output)
+        np.testing.assert_allclose(test_output, exp_output, rtol=1e-12, atol=1e-12)
 
     def test_corrcoef_matrix_vector_varrow(self):
         '''Test for corrcoef (matrix and vector, var=row)'''


### PR DESCRIPTION
This PR addresses the remaining floating-point assertion issues discussed in #129.

Some of these issues were addressed in #112, but similar strict assertions remained in other tests. This PR updates only assertions involving numerical computations to use tolerant comparisons, while keeping exact comparisons where exact matches are expected.

Changes in this PR:

* Replaces strict equality checks with tolerant comparisons for floating-point computations.
* Adds an explicit `atol` to an existing `np.testing.assert_allclose(...)` assertion that failed due to a very small numerical difference.
* Updates `self.assertTrue(np.allclose(...))` in `test_metric.py` to `np.testing.assert_allclose(...)`, and sets stricter explicit tolerances (`rtol=1e-12`, `atol=1e-12`) instead of relying on the default `np.allclose` tolerances (`rtol=1e-05`, `atol=1e-08`).

For `test_metric.py`, #112 had already updated these assertions, but I revised them again to follow the style suggested in #117. `np.testing.assert_allclose(...)` reports the actual numerical differences on failure, making failures easier to diagnose than a generic `False is not true`-style message.

Since this PR changes test assertions, I ran the tests locally three times with multiple Python versions and confirmed that they did not fail.

Closes #129