### PR TITLE
Mechanical lint and type check fixes

### DIFF
--- a/bdpy/__init__.py
+++ b/bdpy/__init__.py
@@ -6,6 +6,12 @@ Developed by Kamitani Lab, Kyoto Univ. and ATR.
 
 # `import bdpy` implicitly imports class `BData` (in package `bdata`) and
 # package `util`.
-from .bdata import BData
-from .bdata import vstack, metadata_equal
-from .util import create_groupvector, divide_chunks, get_refdata, makedir_ifnot, dump_info, average_elemwise
+from .bdata import BData, metadata_equal, vstack
+from .util import (
+    average_elemwise,
+    create_groupvector,
+    divide_chunks,
+    dump_info,
+    get_refdata,
+    makedir_ifnot,
+)

--- a/bdpy/bdata/__init__.py
+++ b/bdpy/bdata/__init__.py
@@ -5,4 +5,4 @@ This package is a part of BdPy.
 
 
 from .bdata import BData
-from .utils import concat_dataset, vstack, metadata_equal
+from .utils import concat_dataset, metadata_equal, vstack

--- a/bdpy/bdata/bdata.py
+++ b/bdpy/bdata/bdata.py
@@ -7,22 +7,20 @@ This file is a part of BdPy.
 __all__ = ['BData']
 
 
-from typing import Optional, Tuple, Union
-
-import os
-import warnings
-import time
 import datetime
 import inspect
+import os
 import re
+import time
+import warnings
+from typing import Optional, Tuple, Union
 
 import h5py
 import numpy as np
 import scipy.io as sio
 
-from .metadata import MetaData
 from .featureselector import FeatureSelector
-
+from .metadata import MetaData
 
 # BData class ##########################################################
 

--- a/bdpy/bdata/bdata.py
+++ b/bdpy/bdata/bdata.py
@@ -51,10 +51,10 @@ class BData(object):
 
     def __init__(self, file_name: Optional[str] = None, file_type: Optional[str] = None) -> None:
         """Initialize BData instance."""
-        self.__dataset = np.ndarray((0, 0), dtype=float)
+        self.__dataset: np.ndarray = np.ndarray((0, 0), dtype=float)
         self.__metadata = MetaData()
-        self.__header = {}
-        self.__vmap = {}
+        self.__header: dict = {}
+        self.__vmap: dict = {}
 
         if file_name is not None:
             self.load(file_name, file_type)
@@ -368,7 +368,7 @@ class BData(object):
         """
         expr_rpn = FeatureSelector(condition).rpn
 
-        stack = []
+        stack: list = []
         buf_sel = []
 
         for i in expr_rpn:

--- a/bdpy/bdata/featureselector.py
+++ b/bdpy/bdata/featureselector.py
@@ -1,12 +1,12 @@
-'''
+"""
 Feature selector class
 
 This file is a part of BdPy
-'''
+"""
 
 
 class FeatureSelector(object):
-    '''
+    """
     Feature selector class
 
     Parameters
@@ -22,7 +22,7 @@ class FeatureSelector(object):
         Tokens
     rpn : tuple
         Tokens in reversed polish notation
-    '''
+    """
 
     # Class variables ##################
     signs = ('(', ')')
@@ -47,8 +47,7 @@ class FeatureSelector(object):
         self.index = None
 
     def lexical_analysis(self, expression):
-        '''Lexical analyser'''
-
+        """Lexical analyser"""
         str_buf = ''
         output_buf = []
 
@@ -93,8 +92,7 @@ class FeatureSelector(object):
         return tuple(output_buf)
 
     def parse(self, token_list):
-        '''Parser for selection command'''
-
+        """Parser for selection command"""
         out_que = []
         op_stack = []
 

--- a/bdpy/bdata/metadata.py
+++ b/bdpy/bdata/metadata.py
@@ -16,7 +16,6 @@ class MetaData(object):
     'value', and 'description'.
     """
 
-
     def __init__(self, key=None, value=None, description=None):
         if key is None:
             key = []
@@ -69,7 +68,6 @@ class MetaData(object):
             Function applied to meta-data value when meta-data named `key` already exists.
             It should take two args: new and old meta-data values.
         """
-
         # If `value` is None, `set` does not update the value.
         is_novalue = True if value is None else False
 

--- a/bdpy/bdata/utils.py
+++ b/bdpy/bdata/utils.py
@@ -1,9 +1,8 @@
 """Utility functions for BData."""
 
 
-from typing import List
-
 import copy
+from typing import List
 
 import numpy as np
 
@@ -40,7 +39,6 @@ def vstack(bdata_list, successive=[], metadata_merge='strict', ignore_metadata_d
 
         data = vstack([data0, data1, data2], successive=['Session', 'Run', 'Block'])
     """
-
     suc_cols = {s : 0 for s in successive}
 
     dat = BData()  # Concatenated BData
@@ -136,7 +134,7 @@ def resolve_vmap(bdata_list):
             new_dsvalues = copy.deepcopy(ds_values)  # to update
 
             # Sanity check
-            if not vmap_key in ds.metadata.key:
+            if vmap_key not in ds.metadata.key:
                 raise ValueError('%s not found in metadata.' % vmap_key)
             if type(vmap) is not dict:
                 raise TypeError('`vmap` should be a dictionary.')
@@ -197,7 +195,6 @@ def concat_dataset(data_list, successive=[]):
 
         data = concat_dataset([data0, data1, data2], successive=['Session', 'Run', 'Block'])
     """
-
     return vstack(data_list, successive=successive)
 
 
@@ -213,7 +210,6 @@ def metadata_equal(d0, d1, strict=False):
     -------
     bool
     """
-
     equal = True
 
     # Strict check

--- a/bdpy/dataform/__init__.py
+++ b/bdpy/dataform/__init__.py
@@ -4,8 +4,8 @@ BdPy data format package
 This package is a part of BdPy
 """
 
-from .pd import *
 from .datastore import *
-from .sparse import *
 from .features import *
 from .kvs import SQLite3KeyValueStore
+from .pd import *
+from .sparse import *

--- a/bdpy/dataform/datastore.py
+++ b/bdpy/dataform/datastore.py
@@ -1,26 +1,25 @@
-'''DataStore class
+"""DataStore class
 
 This file is a part of BdPy.
-'''
+"""
 
 
 from __future__ import print_function
 
-import os
 import glob
+import os
 import re
 
-import numpy as np
-import scipy.io as sio
 import h5py
 import hdf5storage
-
+import numpy as np
+import scipy.io as sio
 
 __all__ = ['DataStore', 'DirStore']
 
 
 class DataStore(object):
-    '''Data store class.
+    """Data store class.
 
     Parameters
     ----------
@@ -35,7 +34,6 @@ class DataStore(object):
 
     Examples
     --------
-
     Suppose you have mat files in ``/path/to/data/dir/``. Each file has a name
     such as ``subject1_V1.mat`` and contains variable ``data``.
 
@@ -52,7 +50,7 @@ class DataStore(object):
     - Add input checks.
     - Add recursive file search.
     - Add default file name pattern (`pattern`).
-    '''
+    """
 
     def __init__(self,
                  dpath=None, file_type=None,
@@ -76,7 +74,7 @@ class DataStore(object):
                 self.__parse_datafiles(p)
 
     def get(self, *keys):
-        '''Get data specified by keys.
+        """Get data specified by keys.
 
         Parameters
         ----------
@@ -86,20 +84,19 @@ class DataStore(object):
         Returns
         -------
         All variables in a file (dict) or extracted data.
-        '''
-
+        """
         fpath = self.__get_file_from_keys(keys)
         dat = self.__load_data(fpath, self.extractor)
 
         return dat
 
     def __get_file_from_keys(self, keys_lst):
-        '''Get file path specified by `keys_lst`.'''
+        """Get file path specified by `keys_lst`."""
         key = self.__key_sep.join(keys_lst)
         return self.file_dict[key]
 
     def __load_data(self, fpath, extractor):
-        '''Load data in `fpath`.'''
+        """Load data in `fpath`."""
         print('Loading ' + fpath)
 
         if self.file_type is None:
@@ -128,13 +125,12 @@ class DataStore(object):
                 return extractor(f)
 
     def __get_key_num(self, pat):
-        '''Return no. of keys.'''
+        """Return no. of keys."""
         n_keys = len(re.findall('\(.*?\)', pat))
         return n_keys
 
     def __parse_datafiles(self, dpath):
-        '''Parse files in `dpath`.'''
-
+        """Parse files in `dpath`."""
         print('Searching %s' % dpath)
 
         if not os.path.isdir(dpath):
@@ -160,7 +156,7 @@ class DataStore(object):
 
 
 class DirStore(object):
-    '''Directory-based data store class.
+    """Directory-based data store class.
 
     Parameters
     ----------
@@ -181,7 +177,7 @@ class DirStore(object):
         Squeeze the data if True.
 
 
-    '''
+    """
 
     def __init__(self, dpath,
                  dirs_pattern=[],
@@ -198,11 +194,10 @@ class DirStore(object):
         self._file_names = []
 
     def get(self, **kargs):
-        '''Returns data specified by kargs.
+        """Returns data specified by kargs.
 
         Examples
         --------
-
         Suppose files are organized as ``<dpath>/<layer>/<subject>/<roi>/<image>.mat``.
 
         >>> ds = DirStore('./data/dir',
@@ -213,8 +208,7 @@ class DirStore(object):
 
         The above code reads ``./data/dir/conv1/sub-01/VC/Image_001.mat`` and
         returns variable ``'feat'`` in the file.
-        '''
-
+        """
         # Sub-directories
         subdir_path = os.path.join(*[kargs[p] for p in self.__dirs_pattern])
 

--- a/bdpy/dataform/features.py
+++ b/bdpy/dataform/features.py
@@ -1,28 +1,25 @@
-'''DNN features class
-
+"""DNN features class
 
 This file is a part of BdPy.
-'''
+"""
 
 
 from __future__ import print_function
 
+__all__ = ['DecodedFeatures', 'Features', 'save_feature']
 
-__all__ = ['Features', 'DecodedFeatures', 'save_feature']
-
-from typing import Any, Optional, Union, List, Dict
-
-from functools import partial
-import os
 import glob
-import sqlite3
+import os
 import pickle
+import sqlite3
 import warnings
+from functools import partial
 from multiprocessing import Pool
+from typing import Any, Dict, List, Optional, Union
 
+import hdf5storage
 import numpy as np
 import scipy.io as sio
-import hdf5storage
 
 
 def _load_array_with_key(key: str, path: str) -> np.ndarray:
@@ -48,7 +45,7 @@ def _determine_num_parallel(num_files: int) -> int:
 
 
 class Features(object):
-    '''DNN features class.
+    """DNN features class.
 
     Parameters
     ----------
@@ -65,7 +62,7 @@ class Features(object):
         List of stimulus index (one-based)
     layers: list
         List of DNN layers
-    '''
+    """
 
     def __init__(
             self, dpath: Union[str, List[str]] = [],
@@ -119,7 +116,7 @@ class Features(object):
         return self.__feature_index
 
     def get(self, layer: str, label: Union[str, List[str], None] = None) -> np.ndarray:
-        '''Return features in `layer`.
+        """Return features in `layer`.
 
         Parameters
         ----------
@@ -132,8 +129,7 @@ class Features(object):
         -------
         numpy.ndarray, shape=(n_samples, shape_layers)
             DNN features
-        '''
-
+        """
         if label is None:
             return self.get_features(layer)
 
@@ -197,7 +193,7 @@ class Features(object):
         return s
 
     def get_features(self, layer: str) -> np.ndarray:
-        '''Return features in `layer`.
+        """Return features in `layer`.
 
         Parameters
         ----------
@@ -208,8 +204,7 @@ class Features(object):
         -------
         numpy.ndarray, shape=(n_samples, shape_layers)
             DNN features
-        '''
-
+        """
         if layer == self.__c_feature_name:
             assert isinstance(self.__features, np.ndarray)
             return self.__features  # self.__features could be None
@@ -290,13 +285,13 @@ class Features(object):
 
 
 class DecodedFeatures(object):
-    '''Decoded features class.
+    """Decoded features class.
 
     Parameters
     ----------
     path: str
         Path to the decoded feature directory
-    '''
+    """
 
     def __init__(
             self, path: str, keys: Optional[List[str]] = None, file_ext: str = 'mat',
@@ -359,8 +354,7 @@ class DecodedFeatures(object):
         return self.__db.get_selected_values('label')
 
     def get(self, layer=None, subject=None, roi=None, fold=None, label=None, image=None):
-        '''Returns decoded features as an array.'''
-
+        """Returns decoded features as an array."""
         if image is not None:
             if label is None:
                 warnings.warn('`image` will be deprecated.')
@@ -499,13 +493,13 @@ class FileDatabase(object):
         return [a[-1] for a in self.__res]
 
     def get_available_values(self, key: str):
-        if not key in self.__keys:
+        if key not in self.__keys:
             return None
         self.__cursor.execute('SELECT DISTINCT {} FROM files'.format(key))
         return [a[0] for a in self.__cursor.fetchall()]
 
     def get_selected_values(self, key):
-        if not key in self.__keys:
+        if key not in self.__keys:
             return None
         # NOTE: self.__res could be None
         # This design forces users to call get_file() before get_selected_values()
@@ -517,7 +511,7 @@ class FileDatabase(object):
 
 
 def save_feature(feature: np.ndarray, base_dir: str, layer: str, label: str, verbose: bool = False):
-    '''
+    """
     Save features.
 
     Parameters
@@ -531,8 +525,7 @@ def save_feature(feature: np.ndarray, base_dir: str, layer: str, label: str, ver
     Returns
     -------
     None
-    '''
-
+    """
     save_dir = os.path.join(base_dir, layer)
     os.makedirs(save_dir, exist_ok=True)
 

--- a/bdpy/dataform/kvs.py
+++ b/bdpy/dataform/kvs.py
@@ -1,14 +1,12 @@
 """Key-value store."""
 
 
-from typing import List, Tuple, Union, Optional
-
 import os
 import sqlite3
 from pathlib import Path
+from typing import List, Optional, Union
 
 import numpy as np
-
 
 _array_t = np.ndarray
 _path_t = Union[str, Path]

--- a/bdpy/dataform/pd.py
+++ b/bdpy/dataform/pd.py
@@ -1,17 +1,17 @@
-'''Utilities for Pandas dataframe
+"""Utilities for Pandas dataframe
 
 This file is a part of BdPy
-'''
+"""
 
 
-__all__ = ['convert_dataframe', 'append_dataframe']
+__all__ = ['append_dataframe', 'convert_dataframe']
 
 
 import pandas as pd
 
 
 def convert_dataframe(lst):
-    '''Convert `lst` to Pandas dataframe
+    """Convert `lst` to Pandas dataframe
 
     Parameters
     ----------
@@ -20,15 +20,14 @@ def convert_dataframe(lst):
     Returns
     -------
     Pandas dataframe
-    '''
-
+    """
     df_lst = (pd.DataFrame([item.values()], columns=item.keys()) for item in lst)
     df = pd.concat(df_lst, axis=0, ignore_index=True)
     return df
 
 
 def append_dataframe(df, **kwargs):
-    '''Append a row to Pandas dataframe `df`
+    """Append a row to Pandas dataframe `df`
 
     Parameters
     ----------
@@ -38,7 +37,6 @@ def append_dataframe(df, **kwargs):
     Returns
     -------
     Pandas dataframe
-    '''
-
+    """
     df_append = pd.DataFrame({k : [kwargs[k]] for k in kwargs})
     return df.append(df_append, ignore_index=True)

--- a/bdpy/dataform/sparse.py
+++ b/bdpy/dataform/sparse.py
@@ -1,21 +1,20 @@
-'''Sparse array class.
+"""Sparse array class.
 
 This file is a part of bdpy.
-'''
+"""
 
 __all__ = ['SparseArray', 'load_array', 'save_array', 'save_multiarrays']
 
 
 import os
 
-import numpy as np
 import h5py
 import hdf5storage
+import numpy as np
 
 
 def load_array(fname, key='data'):
-    '''Load an array (dense or sparse).'''
-
+    """Load an array (dense or sparse)."""
     with h5py.File(fname, 'r') as f:
         methods = [attr for attr in dir(f[key]) if callable(getattr(f[key], str(attr)))]
         if 'keys' in methods and '__bdpy_sparse_arrray' in f[key].keys():
@@ -30,8 +29,7 @@ def load_array(fname, key='data'):
 
 
 def save_array(fname, array, key='data', dtype=np.float64, sparse=False):
-    '''Save an array (dense or sparse).'''
-
+    """Save an array (dense or sparse)."""
     if sparse:
         # Save as a SparseArray
         s_ary = SparseArray(array.astype(dtype))
@@ -47,8 +45,7 @@ def save_array(fname, array, key='data', dtype=np.float64, sparse=False):
 
 
 def save_multiarrays(fname, arrays):
-    '''Save arrays (dense).'''
-
+    """Save arrays (dense)."""
     save_dict = {k: v for k, v in arrays.items()}
     hdf5storage.savemat(fname,
                         save_dict,
@@ -59,7 +56,7 @@ def save_multiarrays(fname, arrays):
 
 
 class SparseArray(object):
-    '''Sparse array class.'''
+    """Sparse array class."""
     
     def __init__(self, src=None, key='data', background=0):
         self.__background = background

--- a/bdpy/dataform/utils.py
+++ b/bdpy/dataform/utils.py
@@ -2,8 +2,9 @@
 
 from typing import List, Union
 
-from bdpy.dataform import Features
 import numpy as np
+
+from bdpy.dataform import Features
 
 
 def get_multi_features(features: List[Features], layer: str, labels: Union[List[str], np.ndarray]) -> np.ndarray:

--- a/bdpy/dataset/utils.py
+++ b/bdpy/dataset/utils.py
@@ -1,12 +1,10 @@
 """Dataset utilities."""
 
-from typing import List, TypedDict, Union
-
 import hashlib
-import inspect
 import os
 import subprocess
 import urllib.request
+from typing import List, TypedDict, Union
 
 from tqdm import tqdm
 

--- a/bdpy/distcomp/__init__.py
+++ b/bdpy/distcomp/__init__.py
@@ -1,6 +1,6 @@
-'''Distributed computation package
+"""Distributed computation package
 
 This package is a part of BdPy.
-'''
+"""
 
 from .distcomp import *

--- a/bdpy/distcomp/distcomp.py
+++ b/bdpy/distcomp/distcomp.py
@@ -1,20 +1,19 @@
-'''Distributed computation module
+"""Distributed computation module
 
 This file is a part of BdPy.
-'''
+"""
 
 
 __all__ = ['DistComp']
 
 
 import os
-import warnings
 import sqlite3
-from contextlib import closing
+import warnings
 
 
 class DistComp(object):
-    '''Distributed computation class'''
+    """Distributed computation class"""
 
     def __init__(self, backend='file', comp_id=None, lockdir='tmp', db_path='./distcomp.db'):
         self.__backend = backend # 'file' or 'sqlite3'
@@ -107,7 +106,7 @@ class DistComp(object):
         return is_locked
 
     def __lockfilename(self, comp_id):
-        '''Return the lock file path'''
+        """Return the lock file path"""
         return os.path.join(self.lockdir, comp_id + '.lock')
 
     def __init_db(self):
@@ -117,7 +116,7 @@ class DistComp(object):
         return None
 
     def __status_db(self, comp_id):
-        '''Return status of `comp_id`.'''
+        """Return status of `comp_id`."""
         with sqlite3.connect(self.__db_path, isolation_level='EXCLUSIVE') as db:
             r = [row[0] for row in db.execute('SELECT STATUS FROM computation WHERE name = "%s"' % comp_id)]
             if len(r) == 0:

--- a/bdpy/dl/caffe.py
+++ b/bdpy/dl/caffe.py
@@ -1,16 +1,17 @@
-'''Caffe module.'''
+"""Caffe module."""
 
 
 import os
 
-import PIL
 import numpy as np
-from bdpy.dataform import save_array
+import PIL
 from tqdm import tqdm
+
+from bdpy.dataform import save_array
 
 
 def extract_image_features(image_file, net, layers=[], crop_center=False, image_preproc=[], save_dir=None, verbose=False, progbar=False, return_features=True):
-    '''
+    """
     Extract DNN features of a given image.
 
     Parameters
@@ -37,8 +38,7 @@ def extract_image_features(image_file, net, layers=[], crop_center=False, image_
     -------
     dict
         Dictionary in which keys are DNN layers and values are features.
-    '''
-
+    """
     if isinstance(image_file, str):
         image_file = [image_file]
 
@@ -108,7 +108,7 @@ def extract_image_features(image_file, net, layers=[], crop_center=False, image_
                 else:
                     features_dict.update({lay: feat})
 
-            if not save_dir is None:
+            if save_dir is not None:
                 # Save the features
                 save_dir_lay = os.path.join(save_dir, lay.replace('/', ':'))
                 save_file = os.path.join(save_dir_lay,

--- a/bdpy/dl/torch/__init__.py
+++ b/bdpy/dl/torch/__init__.py
@@ -1,2 +1,2 @@
-from .torch import FeatureExtractor, ImageDataset
 from .base import *
+from .torch import FeatureExtractor, ImageDataset

--- a/bdpy/dl/torch/base.py
+++ b/bdpy/dl/torch/base.py
@@ -1,6 +1,6 @@
-'''
+"""
 Base classes.
-'''
+"""
 
 
 __all__ = [
@@ -9,23 +9,20 @@ __all__ = [
 ]
 
 
-from typing import Any, Type, Iterable, List, Dict, Tuple, Callable, Union, Optional
-
-import os
+from typing import Any, Dict, Iterable, Optional, Type, Union
 
 import numpy as np
 import torch
 import torch.nn as nn
 
-
 _tensor_t = Union[np.ndarray, torch.Tensor]
 
 
 class DnnFeatureExtractorBase(object):
-    '''
+    """
     Base class for PyTorch DNN feature extractors.
 
-    '''
+    """
 
     def __init__(self, model: Optional[nn.Module] = None, model_cls: Optional[Type[nn.Module]] = None, layers: Iterable[str] = [], device: str = 'cpu', init_args={}):
         self.model = model
@@ -41,22 +38,22 @@ class DnnFeatureExtractorBase(object):
         self.model.to(self.device)
 
     def init(self) -> None:
-        '''
+        """
         Custom initialization method.
         `init_args` in `__init__()` is passed to this function.
-        '''
+        """
         return None
 
     def preprocess(self, x: Any) -> Any:
-        '''
+        """
         Preprocesses the input for the DNN model.
-        '''
+        """
         return x
 
     def extract_features(self, x: Any) -> Dict[str, np.ndarray]:
-        '''
+        """
         Extracts features from the given input using the DNN model.
-        '''
+        """
         raise NotImplementedError("Subclass must implement extract_features method.")
 
     def __call__(self, x: Any, **kwargs) -> Dict[str, _tensor_t]:
@@ -64,10 +61,10 @@ class DnnFeatureExtractorBase(object):
 
 
 class ReconstructionBase(object):
-    '''
+    """
     Base class for reconstruction.
 
-    '''
+    """
 
     def __init__(self, model: Optional[nn.Module] = None, model_cls: Optional[Type[nn.Module]] = None, layers: Iterable[str] = [], device: str = 'cpu', init_args={}):
         self.model = model
@@ -83,22 +80,22 @@ class ReconstructionBase(object):
         self.model.to(self.device)
 
     def init(self) -> None:
-        '''
+        """
         Custom initialization method.
         `init_args` in `__init__()` is passed to this function.
-        '''
+        """
         return None
 
     def preprocess(self, x: Any) -> Any:
-        '''
+        """
         Preprocesses the input for the DNN model.
-        '''
+        """
         return x
 
     def reconstruct(self, x: Any) -> Any:
-        '''
+        """
         Reconstruction from the given input.
-        '''
+        """
         raise NotImplementedError("Subclass must implement reconstruct method.")
 
     def __call__(self, x: Any, **kwargs) -> Any:

--- a/bdpy/dl/torch/dataset.py
+++ b/bdpy/dl/torch/dataset.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import Iterable, Callable, Dict
-
 from pathlib import Path
+from typing import Callable, Dict, Iterable
 
-from PIL import Image
 import numpy as np
+from PIL import Image
 from torch.utils.data import Dataset
 
 from bdpy.dataform import DecodedFeatures, Features
-
 
 _FeatureTypeNP = Dict[str, np.ndarray]
 

--- a/bdpy/dl/torch/domain/__init__.py
+++ b/bdpy/dl/torch/domain/__init__.py
@@ -1,1 +1,7 @@
-from .core import Domain, InternalDomain, IrreversibleDomain, ComposedDomain, KeyValueDomain
+from .core import (
+    ComposedDomain,
+    Domain,
+    InternalDomain,
+    IrreversibleDomain,
+    KeyValueDomain,
+)

--- a/bdpy/dl/torch/domain/core.py
+++ b/bdpy/dl/torch/domain/core.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Iterable, TypeVar, Generic
 import warnings
+from abc import ABC, abstractmethod
+from typing import Generic, Iterable, TypeVar
 
 import torch.nn as nn
 

--- a/bdpy/dl/torch/domain/image_domain.py
+++ b/bdpy/dl/torch/domain/image_domain.py
@@ -18,7 +18,7 @@ import numpy as np
 import torch
 from torchvision.transforms import InterpolationMode, Resize
 
-from .core import Domain, InternalDomain, IrreversibleDomain, ComposedDomain
+from .core import ComposedDomain, Domain, InternalDomain, IrreversibleDomain
 
 
 def _bgr2rgb(images: torch.Tensor) -> torch.Tensor:

--- a/bdpy/dl/torch/models.py
+++ b/bdpy/dl/torch/models.py
@@ -1,10 +1,9 @@
 """Model definitions."""
 
 
-from typing import Dict, Union, Optional, Sequence
-
 import re
 from functools import reduce
+from typing import Dict, Optional, Sequence, Union
 
 import torch
 import torch.nn as nn
@@ -24,7 +23,6 @@ def layer_map(net: str) -> Dict[str, str]:
         Layer map. Keys are human-readable layer names, and values are
         corresponding layer names in the network.
     """
-
     maps = {
         'vgg19': {
             'conv1_1': 'features[0]',
@@ -144,7 +142,6 @@ def _parse_layer_name(model: nn.Module, layer_name: str) -> nn.Module:
 
 def model_factory(name: str) -> nn.Module:
     """Make a model instrance."""
-
     if name == "alexnet":
         return AlexNet()
     elif name == "reference_net":

--- a/bdpy/dl/torch/torch.py
+++ b/bdpy/dl/torch/torch.py
@@ -1,16 +1,15 @@
-'''PyTorch module.'''
+"""PyTorch module."""
 
 from __future__ import annotations
 
-from typing import Iterable, List, Dict, Union, Tuple, Any, Callable, Optional
-from collections import OrderedDict
 import os
 import warnings
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
-from PIL import Image
 import torch
 import torch.nn as nn
+from PIL import Image
 
 from . import models
 
@@ -23,7 +22,7 @@ class FeatureExtractor(object):
             layer_mapping: Optional[Dict[str, str]] = None,
             device: str = 'cpu', detach: bool = True
     ):
-        '''Feature extractor.
+        """Feature extractor.
 
         Parameters
         ----------
@@ -38,8 +37,7 @@ class FeatureExtractor(object):
             Device name (default: 'cpu').
         detach : bool, optional
             If True, detach the feature activations from the computation graph
-        '''
-
+        """
         self._encoder = encoder
         self.__layers = layers
         self.__layer_map = layer_mapping
@@ -63,7 +61,7 @@ class FeatureExtractor(object):
         return self.run(x)
 
     def run(self, x: _tensor_t) -> Dict[str, np.ndarray] | Dict[str, torch.Tensor]:
-        '''Extract feature activations from the specified layers.
+        """Extract feature activations from the specified layers.
 
         Parameters
         ----------
@@ -75,8 +73,7 @@ class FeatureExtractor(object):
         features : Dict[str, Union[numpy.ndarray, torch.Tensor]]
             Feature activations from the specified layers.
             Each key is the layer name and each value is the feature activation.
-        '''
-
+        """
         self._extractor.clear()
         if not isinstance(x, torch.Tensor):
             xt = torch.tensor(x[np.newaxis], device=self.__device)
@@ -98,10 +95,10 @@ class FeatureExtractor(object):
         }
     
     def __del__(self):
-        '''
+        """
         Remove forward hooks for the FeatureExtractor while keeping
         other forward hooks in the model.
-        '''
+        """
         for layer in self.__layers:
             if self.__layer_map is not None:
                 layer = self.__layer_map[layer]
@@ -142,7 +139,7 @@ class FeatureExtractorHandleDetach(object):
 
 
 class ImageDataset(torch.utils.data.Dataset):
-    '''Pytoch dataset for images.'''
+    """Pytoch dataset for images."""
 
     def __init__(
             self, images: List[str],
@@ -156,7 +153,7 @@ class ImageDataset(torch.utils.data.Dataset):
             preload: bool = False,
             preload_limit: float = np.inf
     ):
-        '''Initialize ImageDataset.
+        """Initialize ImageDataset.
 
         Parameters
         ----------
@@ -184,8 +181,7 @@ class ImageDataset(torch.utils.data.Dataset):
         Note
         ----
         - Images are converted to RGB. Alpha channels in RGBA images are ignored.
-        '''
-
+        """
         warnings.warn(
             "dl.torch.torch.ImageDataset is deprecated. Please consider using " \
             "bdpy.dl.torch.dataset.ImageDataset instead.",
@@ -219,7 +215,7 @@ class ImageDataset(torch.utils.data.Dataset):
                 preload_size += data_size
 
         self.data_path = images
-        if not labels is None:
+        if labels is not None:
             self.labels = labels
         else:
             self.labels = image_labels
@@ -261,7 +257,7 @@ class ImageDataset(torch.utils.data.Dataset):
             data = np.stack([data, data, data], axis=2)
 
         # Resize the image
-        if not self.__resize is None:
+        if self.__resize is not None:
             data = np.array(Image.fromarray(data).resize(self.__resize, resample=2))  # bicubic
 
         # Reshape
@@ -274,7 +270,7 @@ class ImageDataset(torch.utils.data.Dataset):
         data = (data / 255.) * self.__scale
 
         # Centering
-        if not self.__rgb_mean is None:
+        if self.__rgb_mean is not None:
             data[0] -= self.__rgb_mean[0]
             data[1] -= self.__rgb_mean[1]
             data[2] -= self.__rgb_mean[2]

--- a/bdpy/evals/metrics.py
+++ b/bdpy/evals/metrics.py
@@ -1,4 +1,4 @@
-'''bdpy.evals.metrics'''
+"""bdpy.evals.metrics"""
 
 import warnings
 
@@ -7,8 +7,7 @@ from scipy.spatial.distance import cdist
 
 
 def profile_correlation(x, y):
-    '''Profile correlation.'''
-
+    """Profile correlation."""
     sample_axis = 0
 
     orig_shape = x.shape
@@ -35,8 +34,7 @@ def profile_correlation(x, y):
 
 
 def pattern_correlation(x, y, mean=None, std=None, remove_nan=True):
-    '''Pattern correlation.'''
-
+    """Pattern correlation."""
     sample_axis = 0
 
     orig_shape = x.shape
@@ -74,11 +72,10 @@ def pattern_correlation(x, y, mean=None, std=None, remove_nan=True):
 
 
 def pattern_cross_correlation(x, y, mean=None, std=None, remove_nan=True):
-    '''Pattern correlation. 
-     Output: cross correlation of size (n_sample, n_sample).
-     The (i,j) element of r corresponds to the correlation between i-th row of x and j-th row of y.
-    '''
-
+    """Pattern correlation.
+    Output: cross correlation of size (n_sample, n_sample).
+    The (i,j) element of r corresponds to the correlation between i-th row of x and j-th row of y.
+    """
     sample_axis = 0
 
     orig_shape = x.shape
@@ -113,8 +110,7 @@ def pattern_cross_correlation(x, y, mean=None, std=None, remove_nan=True):
 
 
 def pairwise_identification(pred, true, metric='correlation', remove_nan=True, remove_nan_dist=True, single_trial=False, pred_labels=None, true_labels=None):
-    '''Pair-wise identification.'''
-
+    """Pair-wise identification."""
     p = pred.reshape(pred.shape[0], -1)
     t = true.reshape(true.shape[0], -1)
 
@@ -160,7 +156,7 @@ def pairwise_identification(pred, true, metric='correlation', remove_nan=True, r
 
 
 def remove_nan_value(array, nan_flag=None, return_nan_flag=False):
-    '''Remove columns (units) which contain NaN values.
+    """Remove columns (units) which contain NaN values.
 
     Parameters
     ----------
@@ -179,8 +175,7 @@ def remove_nan_value(array, nan_flag=None, return_nan_flag=False):
     nan_flag : numpy.ndarray
         Boolean mask used for removal. Only returned when
         ``return_nan_flag=True``.
-    '''
-
+    """
     if nan_flag is None:
         nan_flag = np.isnan(array).any(axis=0)
     nan_removed_array = array[:, ~nan_flag]

--- a/bdpy/feature/__init__.py
+++ b/bdpy/feature/__init__.py
@@ -1,3 +1,3 @@
-'''Feature engineering module.'''
+"""Feature engineering module."""
 
 from .feature import normalize_feature

--- a/bdpy/feature/feature.py
+++ b/bdpy/feature/feature.py
@@ -7,7 +7,7 @@ def normalize_feature(feature,
                       std_ddof=1,
                       shift=None, scale=None,
                       scaling_only=False):
-    '''Normalize feature.
+    """Normalize feature.
 
     Parameters
     ----------
@@ -28,8 +28,7 @@ def normalize_feature(feature,
     -------
     ndarray
         Normalized (and scaled/shifted) features.
-    '''
-
+    """
     if feature.ndim == 1:
         axes_along = None
     else:
@@ -58,9 +57,9 @@ def normalize_feature(feature,
     else:
         feat_n = ((feature - feat_mean) / feat_std)
 
-        if not scale is None:
+        if scale is not None:
             feat_n = feat_n * scale
-        if not shift is None:
+        if shift is not None:
             feat_n = feat_n + shift
 
     if not feature.shape == feat_n.shape:

--- a/bdpy/fig/__init__.py
+++ b/bdpy/fig/__init__.py
@@ -1,10 +1,10 @@
-'''Figure package
+"""Figure package
 
 This package is a part of BdPy.
-'''
+"""
 
-from .fig import *
-from .tile_images import tile_images
 from .draw_group_image_set import draw_group_image_set
+from .fig import *
 from .makeplots import makeplots
 from .makeplots2 import makeplots2
+from .tile_images import tile_images

--- a/bdpy/fig/draw_group_image_set.py
+++ b/bdpy/fig/draw_group_image_set.py
@@ -4,8 +4,8 @@ import numpy as np
 import PIL
 import PIL.ImageDraw
 import PIL.ImageFont
-import matplotlib
 from matplotlib import font_manager
+
 
 def expand2square(pil_img, background_color):
     width, height = pil_img.size
@@ -64,7 +64,6 @@ def draw_group_image_set(condition_list, background_color = (255, 255, 255),
         List of id names.
         This list is required when `id_show` is True.
     """
-
     #------------------------------------
     # Setting
     #------------------------------------
@@ -72,7 +71,7 @@ def draw_group_image_set(condition_list, background_color = (255, 255, 255),
     for condition in condition_list:
         if not condition.get("image_filepath_list") and not condition.get("image_list"):
             raise RuntimeError("The element of `condition_list` needs `image_filepath_list` or `image_list`.")
-            return;
+            return
         elif condition.get("image_filepath_list") and not condition.get("image_list"):
             condition["image_list"] = condition["image_filepath_list"]
 
@@ -105,7 +104,7 @@ def draw_group_image_set(condition_list, background_color = (255, 255, 255),
             # Load image
             an_image = image_list[tind]
             if an_image is None: # skip
-                continue;
+                continue
             elif isinstance(an_image, str): # str: filepath
                 image_obj = PIL.Image.open(an_image)
             elif isinstance(an_image, np.ndarray): # np.ndarray: array

--- a/bdpy/fig/fig.py
+++ b/bdpy/fig/fig.py
@@ -1,4 +1,4 @@
-'''Figure module
+"""Figure module
 
 This file is a part of BdPy.
 
@@ -10,7 +10,7 @@ box_off
     Remove upper and right axes
 draw_footnote
     Draw footnote on a figure
-'''
+"""
 
 
 __all__ = [
@@ -27,8 +27,7 @@ import seaborn as sns
 
 
 def makefigure(figtype='a4landscape'):
-    '''Create a figure'''
-
+    """Create a figure"""
     if figtype == 'a4landscape':
         figsize = (11.7, 8.3)
     elif figtype == 'a4portrait':
@@ -40,8 +39,7 @@ def makefigure(figtype='a4landscape'):
 
 
 def box_off(ax):
-    '''Remove upper and right axes'''
-
+    """Remove upper and right axes"""
     ax.spines['right'].set_visible(False)
     ax.spines['top'].set_visible(False)
     ax.xaxis.set_ticks_position('bottom')
@@ -49,7 +47,7 @@ def box_off(ax):
 
 
 def draw_footnote(fig, string, fontsize=9):
-    '''Draw footnote on a figure'''
+    """Draw footnote on a figure"""
     ax = fig.add_axes([0., 0., 1., 1.])
     ax.text(0.5, 0.01, string, horizontalalignment='center', fontsize=fontsize)
     ax.patch.set_alpha(0.0)

--- a/bdpy/fig/makeplots.py
+++ b/bdpy/fig/makeplots.py
@@ -1,8 +1,7 @@
 import warnings
 
-import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -35,7 +34,7 @@ def makeplots(
         removenan=True,
         verbose=False, colors=None, reverse_x=False
 ):
-    '''Make plots.
+    """Make plots.
 
     Parameters
     ----------
@@ -61,8 +60,7 @@ def makeplots(
     Returns
     -------
     fig : matplotlib.figure.Figure or list of matplotlib.figure.Figure
-    '''
-
+    """
     x_keys       = sorted(df[x].unique())
     subplot_keys = sorted(df[subplot].unique()) if subplot is not None else [None]
     figure_keys  = sorted(df[figure].unique()) if figure is not None else [None]

--- a/bdpy/fig/makeplots2.py
+++ b/bdpy/fig/makeplots2.py
@@ -1,13 +1,12 @@
 from itertools import product
-
 from typing import Callable
 
-import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
-from matplotlib.colors import to_rgba
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from matplotlib.colors import to_rgba
 
 from bdpy.fig import box_off
 
@@ -32,7 +31,7 @@ def makeplots2(
         makeplots_kws={},
         verbose=False,
 ):
-    '''Make plots.
+    """Make plots.
 
     Parameters
     ----------
@@ -60,7 +59,7 @@ def makeplots2(
     Returns
     -------
     fig : matplotlib.figure.Figure or list of matplotlib.figure.Figure
-    '''
+    """
     # Check plot keys
     x_keys       = sorted(df[x].unique())
     group_keys   = sorted(df[group].unique()) if group is not None else [None]
@@ -408,11 +407,11 @@ def __plot_violin(
     group=None, group_list=[],
     color='#023eff', color_palette='bright', width=0.8, alpha=0.4, points=100,
 ):
-    '''
+    """
     Violin plot.
     * Since seaborn's violin plot does not support drawing control of mean values, 
     this is the only plot sub function based on matplotlib.
-    '''
+    """
     if group is None:
         # prepare data
         xpos = np.arange(len(x_list))

--- a/bdpy/fig/tile_images.py
+++ b/bdpy/fig/tile_images.py
@@ -1,15 +1,15 @@
 import math
 from itertools import product
 
-import PIL
 import matplotlib.pyplot as plt
+import PIL
 from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
 
 
 def tile_images(images, ncols=None, columned=False, labels=None, fig=None,
                 wspace=0, hspace=0.1, horizontal_margin=0.05, vertical_margin=0.05,
                 label_position='inside', label_fontsize=12, label_color='black'):
-    '''Create tiled images.
+    """Create tiled images.
 
     Parameters
     ----------
@@ -42,7 +42,6 @@ def tile_images(images, ncols=None, columned=False, labels=None, fig=None,
 
     Examples
     --------
-
     Three images in a single row (default: all images in one row):
 
     >>> tile_images([image0, image1, image2])
@@ -96,8 +95,7 @@ def tile_images(images, ncols=None, columned=False, labels=None, fig=None,
     | | B3 | B4 | B5 | |
     | +----+----+----+ |
     +------------------+
-    '''
-
+    """
     # Fix `images` to a list of lists
     if not isinstance(images, list):
         images = [[images]]

--- a/bdpy/ml/__init__.py
+++ b/bdpy/ml/__init__.py
@@ -5,10 +5,14 @@ This package is a part of BdPy
 """
 
 
-from .learning import Classification, CrossValidation, ModelTraining, ModelTest
-from .crossvalidation import make_cvindex, make_crossvalidationindex, make_cvindex_generator
-from .crossvalidation import cvindex_groupwise
+from .crossvalidation import (
+    cvindex_groupwise,
+    make_crossvalidationindex,
+    make_cvindex,
+    make_cvindex_generator,
+)
 from .ensemble import *
+from .learning import Classification, CrossValidation, ModelTest, ModelTraining
+from .model import EnsembleClassifier
 from .regress import *
 from .searchlight import *
-from .model import EnsembleClassifier

--- a/bdpy/ml/crossvalidation.py
+++ b/bdpy/ml/crossvalidation.py
@@ -1,14 +1,14 @@
-'''Cross-validation functions
+"""Cross-validation functions
 
 This module provides utility functions for cross-validation.
-'''
+"""
 
 
 import numpy as np
 
 
 def cvindex_groupwise(group, nfolds=None, return_bool=False, exclusive=None):
-    '''Return k-fold iterator for group-wise cross-validation (e.g, run-wise, block-wise, ...)
+    """Return k-fold iterator for group-wise cross-validation (e.g, run-wise, block-wise, ...)
 
     `nfolds` specification are not supported yet.
 
@@ -27,8 +27,7 @@ def cvindex_groupwise(group, nfolds=None, return_bool=False, exclusive=None):
     Returns
     -------
     K-fold iterator
-    '''
-
+    """
     # TODO: add size checking of group
 
     group_set = np.unique(group)  # Unique labels in `group`
@@ -55,7 +54,7 @@ def cvindex_groupwise(group, nfolds=None, return_bool=False, exclusive=None):
             train_labels = exclusive[index_train]
 
             index_train = np.array([
-                ind for ind, lab in zip(index_train, train_labels) if not lab in test_labels
+                ind for ind, lab in zip(index_train, train_labels) if lab not in test_labels
             ])
 
         yield index_train, index_test
@@ -99,14 +98,13 @@ def make_cvindex(group):
                 [False, False,  True],
                 [False, False,  True]], dtype=bool))
     """
-
     # Get and sort unique group index
     group_set = sorted(list(set(group.flatten())))
 
     # The number of sample
-    n_sample = len(group);
+    n_sample = len(group)
     # The number of run
-    n_group = len(group_set);
+    n_group = len(group_set)
 
     if n_group == 0:
         # Training only
@@ -134,12 +132,11 @@ def make_crossvalidationindex(group):
 
     See 'make_cvindex' for the details.
     """
-
     return make_cvindex(group)
 
 
 def make_cvindex_generator(group, folds=None, exclusive=None, return_bool=False):
-    '''Return cross-validation iterator.
+    """Return cross-validation iterator.
 
     n_folds` specification are not supported yet.
 
@@ -158,9 +155,7 @@ def make_cvindex_generator(group, folds=None, exclusive=None, return_bool=False)
     Returns
     -------
     K-fold iterator
-    '''
-
-
+    """
     if folds is None:
         group_set = np.unique(group)
         folds = [{'train': np.delete(group_set, i), 'test': gl} for i, gl in enumerate(group_set)]
@@ -190,7 +185,7 @@ def make_cvindex_generator(group, folds=None, exclusive=None, return_bool=False)
             train_labels = exclusive[index_train]
 
             index_train = np.array([
-                ind for ind, lab in zip(index_train, train_labels) if not lab in test_labels
+                ind for ind, lab in zip(index_train, train_labels) if lab not in test_labels
             ])
 
         yield index_train, index_test

--- a/bdpy/ml/ensemble.py
+++ b/bdpy/ml/ensemble.py
@@ -6,7 +6,6 @@ from collections import Counter
 
 import numpy as np
 
-
 __all__ = ['get_majority']
 
 
@@ -29,7 +28,6 @@ def get_majority(data, axis=0):
     majority_list : list
         A list of majority elements
     """
-
     majority_list = []
 
     if axis == 0:

--- a/bdpy/ml/learning.py
+++ b/bdpy/ml/learning.py
@@ -1,26 +1,26 @@
-'''learning module'''
+"""learning module"""
 
 import sys
 from abc import ABCMeta, abstractmethod
-from typing import cast, Any, Optional, Dict
-if sys.version_info >= (3, 8):
-    from typing import TypedDict, Protocol
-else:
-    from typing_extensions import TypedDict, Protocol
+from typing import Any, Dict, Optional, cast
 
-import os
-import warnings
-import uuid
-import pickle
+if sys.version_info >= (3, 8):
+    from typing import Protocol, TypedDict
+else:
+    from typing_extensions import Protocol, TypedDict
+
 import copy
-import yaml
 import glob
-from time import time, sleep
+import os
+import pickle
+import uuid
 from datetime import datetime
+from time import sleep, time
 
 import numpy as np
+import yaml
 
-from bdpy.dataform import save_array, load_array
+from bdpy.dataform import load_array, save_array
 from bdpy.distcomp import DistComp
 from bdpy.util import makedir_ifnot
 
@@ -39,7 +39,7 @@ class SortIndex(TypedDict):
 
 #-----------------------------------------------------------------------
 class BaseLearning(object):
-    '''Base class for learning'''
+    """Base class for learning"""
 
     __metaclass__ = ABCMeta
 
@@ -52,14 +52,14 @@ class BaseLearning(object):
         pass
 
     def add_preprocessing(self, func, args=None):
-        '''Add preprocessing function'''
+        """Add preprocessing function"""
         self._preprocessing.append({
             'func': func,
             'args': args
         })
 
     def add_postprocessing(self, func, args=None):
-        '''Add postprocessing function'''
+        """Add postprocessing function"""
         self._postprocessing.append({
             'func': func,
             'args': args
@@ -68,7 +68,7 @@ class BaseLearning(object):
 
 #-----------------------------------------------------------------------
 class Classification(BaseLearning):
-    '''Classification class
+    """Classification class
 
     Parameters
     ----------
@@ -89,7 +89,7 @@ class Classification(BaseLearning):
         Predicted labels
     prediction_accuracy
         Prediction accuracy
-   '''
+    """
 
     def __init__(self, x_train=None, y_train=None, x_test=None, y_test=None,
                  classifier=None, verbose='off'):
@@ -109,8 +109,7 @@ class Classification(BaseLearning):
         self.prediction_accuracy = None
 
     def run(self):
-        '''Run classification'''
-
+        """Run classification"""
         self.classifier_trained = copy.deepcopy(self.classifier)
 
         for p in self._preprocessing:
@@ -135,7 +134,7 @@ class Classification(BaseLearning):
 
 #-----------------------------------------------------------------------
 class CrossValidation(BaseLearning):
-    '''Cross-validation class
+    """Cross-validation class
 
     Parameters
     ----------
@@ -156,7 +155,7 @@ class CrossValidation(BaseLearning):
         Trained classifier in each fold
     prediction_accuracy : list
         Prediction accuracy in each fold
-    '''
+    """
 
     def __init__(self, x, y, classifier=None, index=None,
                  keep_classifiers=False, verbose='off'):
@@ -175,13 +174,12 @@ class CrossValidation(BaseLearning):
         self.prediction_accuracy = []
 
     def run(self):
-        '''Run cross-validation
+        """Run cross-validation
 
         Returns
         -------
         None
-        '''
-
+        """
         cls = Classification(x_train=None, y_train=None, x_test=None, y_test=None,
                              classifier=self.classifier, verbose='off')
         for p in self._preprocessing:
@@ -212,7 +210,7 @@ class CrossValidation(BaseLearning):
 
 #-----------------------------------------------------------------------
 class ModelTraining(object):
-    '''Model training with chunking and distributed computation class.
+    """Model training with chunking and distributed computation class.
 
     Attributes
     ----------
@@ -239,7 +237,7 @@ class ModelTraining(object):
     save_path : str
     verbose : int (0 or 1)
         Verbosity level.
-    '''
+    """
 
     def __init__(
             self, model: SupportsFit, X: np.ndarray, Y: np.ndarray,
@@ -285,8 +283,7 @@ class ModelTraining(object):
         self.__pickle_protocol = 4
 
     def run(self):
-        '''Run training.'''
-
+        """Run training."""
         # Chunking
         if self.chunk_axis is None:
             self.__chunking = False
@@ -310,12 +307,12 @@ class ModelTraining(object):
             distcomp = self.distcomp
 
         # X normalization
-        if not self.X_normalize is None:
+        if self.X_normalize is not None:
             print('Normalizing X')
             self.X = (self.X - self.X_normalize['mean']) / self.X_normalize['std']
             self.X[np.isinf(self.X)] = 0
 
-        if not self.X_sort is None:
+        if self.X_sort is not None:
             print('Sorting X')
             self.X = self.X[self.X_sort['index'], :]
 
@@ -353,7 +350,7 @@ class ModelTraining(object):
                 Y = self.Y
 
             # Y preprocessing
-            if not self.Y_normalize is None:
+            if self.Y_normalize is not None:
                 print('Normalizing Y')
                 if self.__chunking:
                     y_mean = np.take(self.Y_normalize['mean'], [i_chunk], axis=self.chunk_axis)
@@ -364,7 +361,7 @@ class ModelTraining(object):
                 Y = (Y - y_mean) / y_norm
                 Y[np.isinf(Y)] = 0
 
-            if not self.Y_sort is None:
+            if self.Y_sort is not None:
                 print('Sorting Y')
                 Y = Y[self.Y_sort['index'], :]
 
@@ -420,7 +417,7 @@ class ModelTraining(object):
                 else:
                     info = {}
 
-                if not '_status' in info:
+                if '_status' not in info:
                     info.update({'_status': {}})
 
                 info['_status'].update({
@@ -462,7 +459,7 @@ class ModelTraining(object):
         return None
 
     def __output_file(self, chunk=0):
-        '''Define output files.'''
+        """Define output files."""
         output_files = []
         if self.save_format == 'pickle':
             # Save the model instance as pickle.
@@ -511,7 +508,7 @@ class ModelTraining(object):
 
 #-----------------------------------------------------------------------
 class ModelTest(object):
-    '''Model test (prediction) class.'''
+    """Model test (prediction) class."""
 
     def __init__(
             self, model: SupportsPredict, X: np.ndarray,
@@ -537,8 +534,7 @@ class ModelTest(object):
         self.__Y_shape = None
 
     def run(self):
-        '''Run test.'''
-
+        """Run test."""
         if self.dtype is not None:
             self.X = self.X.astype(self.dtype)
 

--- a/bdpy/ml/model.py
+++ b/bdpy/ml/model.py
@@ -1,22 +1,23 @@
-'''ML models'''
+"""ML models"""
 
 
 __all__ = []
 
 import copy
+import warnings
 from itertools import product
 
-from bdpy.preproc import select_top
 import numpy as np
 from numpy.linalg import norm
 from scipy import stats
 from sklearn.svm import SVC
 from tqdm import tqdm
-import warnings
+
+from bdpy.preproc import select_top
 
 
 class EnsembleClassifier(object):
-    '''Ensemble classifier.'''
+    """Ensemble classifier."""
 
     def __init__(
             self,
@@ -39,7 +40,7 @@ class EnsembleClassifier(object):
         self._randobj = np.random.RandomState()
 
     def fit(self, X, Y):
-        '''
+        """
         Parameters
         ----------
         X : array of shape (n_samples, n_features)
@@ -49,8 +50,7 @@ class EnsembleClassifier(object):
         Returns
         -------
         self
-        '''
-
+        """
         if Y.ndim == 1:
             self._n_targets = 1
             self._estimators.update({0: {}})
@@ -70,7 +70,7 @@ class EnsembleClassifier(object):
         return self
 
     def _fit(self, X, y, target=0):
-        '''
+        """
         Parameters
         ----------
         X : array of shape (n_samples, n_features)
@@ -81,8 +81,7 @@ class EnsembleClassifier(object):
         Returns
         -------
         self
-        '''
-
+        """
         self._classes.update({target: np.unique(y)})
         y_pairs = self.__get_pairs(self._classes[target])
 
@@ -144,7 +143,7 @@ class EnsembleClassifier(object):
         return self
 
     def predict(self, X):
-        '''
+        """
         Parameters
         ----------
         X : array of shape (n_samples, n_features)
@@ -152,7 +151,7 @@ class EnsembleClassifier(object):
         Returns
         -------
         y_pred : array of shape (n_samples,)
-        '''
+        """
         if self._n_targets == 1:
             return self._predict(X)
 
@@ -169,7 +168,7 @@ class EnsembleClassifier(object):
         return y_pred
 
     def _predict(self, X, target=0):
-        '''
+        """
         Parameters
         ----------
         X : array of shape (n_samples, n_features)
@@ -179,8 +178,7 @@ class EnsembleClassifier(object):
         Returns
         -------
         y_pred : array of shape (n_samples,)
-        '''
-
+        """
         pred_pairs = []
         dv_pairs = []
         for (y0, y1), estimators in self._estimators[target].items():
@@ -225,8 +223,7 @@ class EnsembleClassifier(object):
         return [(y0, y1) for y0, y1 in product(classes, classes) if y0 < y1]
 
     def __undersample(self, x, y):
-        '''The original version was implemented by Misato Tanaka.'''
-
+        """The original version was implemented by Misato Tanaka."""
         y_uniq = np.unique(y)
         min_sample_num = np.min([np.sum(y == u) for u in y_uniq])
 
@@ -250,7 +247,7 @@ class EnsembleClassifier(object):
         return x, y
 
     def __voxel_selection(self, x, y, n_voxel=100):
-        '''Voxel selection based on f values of one-way ANOVA.'''
+        """Voxel selection based on f values of one-way ANOVA."""
         y_uniq = np.unique(y)
         x_sub = [x[y == k, :] for k in y_uniq]
         f, p = stats.f_oneway(*x_sub)
@@ -258,7 +255,7 @@ class EnsembleClassifier(object):
         return index
 
     def __voting(self, y, dv, target=0):
-        '''
+        """
         Parameters
         ----------
         y : array of (n_samples, n_pairs)
@@ -267,7 +264,7 @@ class EnsembleClassifier(object):
         Returns
         -------
         y_pred : array of (n_samples)
-        '''
+        """
         vote = []  # (n_samples, n_classes)
         dv = np.abs(dv)
         for _y, _dv in zip(y, dv):

--- a/bdpy/ml/regress.py
+++ b/bdpy/ml/regress.py
@@ -25,7 +25,6 @@ def add_bias(x, axis=0):
     y : array_like
         Data matrix with bias terms
     """
-
     if axis == 0:
         vlen = x.shape[1]
         y = np.concatenate((x, np.array([np.ones(vlen)])), axis=0)

--- a/bdpy/ml/searchlight.py
+++ b/bdpy/ml/searchlight.py
@@ -1,4 +1,4 @@
-'''Utilities for searchlight analysis.'''
+"""Utilities for searchlight analysis."""
 
 
 __all__ = ['get_neighbors']
@@ -8,7 +8,7 @@ import numpy as np
 
 
 def get_neighbors(xyz, space_xyz, shape='sphere', size=9):
-    '''
+    """
     Returns neighboring voxels (cluster).
 
     Parameters
@@ -26,8 +26,7 @@ def get_neighbors(xyz, space_xyz, shape='sphere', size=9):
     -------
     cluster_index : array_like, dtype=bool, shape=(N,)
         Boolean index of voxels in the cluster.
-    '''
-
+    """
     # Input check
     if isinstance(xyz, list):
         xyz = np.array(xyz)

--- a/bdpy/mri/__init__.py
+++ b/bdpy/mri/__init__.py
@@ -4,10 +4,18 @@ BdPy MRI package
 This package is a part of BdPy
 """
 
+from .fmriprep import FmriprepData, create_bdata_fmriprep
+from .glm import make_paradigm
+from .image import export_brain_image
 from .load_epi import load_epi
 from .load_mri import load_mri
-from .roi import add_roimask, get_roiflag, add_roilabel, add_rois, merge_rois, add_hcp_rois, add_hcp_visual_cortex
-from .fmriprep import create_bdata_fmriprep, FmriprepData
+from .roi import (
+    add_hcp_rois,
+    add_hcp_visual_cortex,
+    add_roilabel,
+    add_roimask,
+    add_rois,
+    get_roiflag,
+    merge_rois,
+)
 from .spm import create_bdata_spm_domestic
-from .image import export_brain_image
-from .glm import make_paradigm

--- a/bdpy/mri/fmriprep.py
+++ b/bdpy/mri/fmriprep.py
@@ -1,25 +1,25 @@
-'''Utilities for fmriprep.'''
+"""Utilities for fmriprep."""
 
 
 import csv
 import glob
 import itertools
+import json
 import os
 import re
-import json
 import warnings
 from collections import OrderedDict
 
-import numpy as np
-import nipy
 import nibabel
+import nipy
+import numpy as np
 import pandas as pd
 
 import bdpy
 
 
 class FmriprepData(object):
-    '''FMRIPREP data class.'''
+    """FMRIPREP data class."""
 
     def __init__(self, datapath=None, fmriprep_version='1.2', fmriprep_dir='derivatives/fmriprep'):
         self.__datapath = datapath
@@ -202,7 +202,7 @@ def create_bdata_fmriprep(dpath, data_mode='volume_native',
                           with_confounds=False,
                           return_data_labels=False,
                           return_list=False):
-    '''Create BData from FMRIPREP outputs.
+    """Create BData from FMRIPREP outputs.
 
     Parameters
     ----------
@@ -225,8 +225,7 @@ def create_bdata_fmriprep(dpath, data_mode='volume_native',
     -------
     BData or list of BData
         One subject, one BData.
-    '''
-
+    """
     print('BIDS data path: %s' % dpath)
 
     # Label mapper
@@ -289,7 +288,7 @@ def create_bdata_fmriprep(dpath, data_mode='volume_native',
                 ex_runs = exclude['session/run'][i]
                 if ex_runs is not None and len(ex_runs) != 0:
                     run_survive = [run for j, run in enumerate(fmriprep.data[sub][ses])
-                                   if not j + 1 in ex_runs]
+                                   if j + 1 not in ex_runs]
                     fmriprep.data[sub][ses] = run_survive
 
     # Split data
@@ -361,7 +360,7 @@ def create_bdata_fmriprep(dpath, data_mode='volume_native',
 
 
 class BrainData(object):
-    '''fMRI data class (volume or surface).'''
+    """fMRI data class (volume or surface)."""
 
     def __init__(self, dpath, dtype='volume'):
         self.__dpath = dpath
@@ -400,13 +399,13 @@ class BrainData(object):
         return self.__n_vertex
 
     def __load_volume(self):
-        '''Load a MRI image.
+        """Load a MRI image.
 
         - Returns data as 2D array (sample x voxel)
         - Returns voxle xyz coordinates (3 x voxel)
         - Returns voxel ijk indexes (3 x voxel)
         - Data, xyz, and ijk are flattened by Fortran-like index order
-        '''
+        """
         img = nipy.load_image(self.__dpath)
 
         data = img.get_data()
@@ -465,21 +464,21 @@ class BrainData(object):
 
 
 class LabelMapper(object):
-    '''Label mapper class.'''
+    """Label mapper class."""
 
     def __init__(self, l2v_map):
         self.__l2v_map = l2v_map
         self.__v2l_map = {}
 
     def get_value(self, mkey, label):
-        if not mkey in self.__l2v_map:
+        if mkey not in self.__l2v_map:
             raise RuntimeError('%s not found in label mapper' % mkey)
 
         if label == 'n/a':
             return np.nan
 
         val = self.__l2v_map[mkey][label]
-        if not mkey in self.__v2l_map:
+        if mkey not in self.__v2l_map:
             self.__v2l_map.update({mkey: {val: label}})
         else:
             if label in self.__v2l_map[mkey].values():
@@ -591,7 +590,7 @@ def __create_bdata_fmriprep_subject(subject_data, data_mode, data_path='./', lab
             motionparam_list.append(mp)
 
             if with_confounds:
-                confounds_keys = [k for k in list(conf_pd.columns) if not k in mp_label_col]
+                confounds_keys = [k for k in list(conf_pd.columns) if k not in mp_label_col]
                 for c in confounds_keys:
                     x = np.c_[conf_pd[c]]
                     if c in confounds:
@@ -770,7 +769,7 @@ def __create_bdata_fmriprep_subject(subject_data, data_mode, data_path='./', lab
 
         cnf_p = 0
         for cnf in default_confounds_keys:
-            if (not cnf in ['a_comp_cor', 't_comp_cor', 'cosine']) and (not cnf in confounds):
+            if (cnf not in ['a_comp_cor', 't_comp_cor', 'cosine']) and (cnf not in confounds):
                 continue
 
             cnf_colidx = np.zeros(confounds_array.shape[1])
@@ -832,13 +831,13 @@ def __get_xyz(img):
 
 
 def __load_mri(fpath):
-    '''Load a MRI image.
+    """Load a MRI image.
 
     - Returns data as 2D array (sample x voxel)
     - Returns voxle xyz coordinates (3 x voxel)
     - Returns voxel ijk indexes (3 x voxel)
     - Data, xyz, and ijk are flattened by Fortran-like index order
-    '''
+    """
     img = nipy.load_image(fpath)
 
     data = img.get_data()

--- a/bdpy/mri/glm.py
+++ b/bdpy/mri/glm.py
@@ -1,14 +1,17 @@
-'''bdpy.mri.glm'''
+"""bdpy.mri.glm"""
 
 
 import csv
 
 import numpy as np
-from nipy.modalities.fmri.experimental_paradigm import BlockParadigm, EventRelatedParadigm
+from nipy.modalities.fmri.experimental_paradigm import (
+    BlockParadigm,
+    EventRelatedParadigm,
+)
 
 
 def make_paradigm(event_files, num_vols, tr=2., cond_col=2, label_col=None, regressors=None, ignore_col=None, ignore_value=[], trial_wise=False, design='block'):
-    '''
+    """
     Make paradigm for GLM with Nipy from BIDS task event files.
 
     Parameters
@@ -41,8 +44,7 @@ def make_paradigm(event_files, num_vols, tr=2., cond_col=2, label_col=None, regr
         condition_labels : labels for task regressors
         run_regressors : nuisance regressors for runs
         run_regressors_label : labels for the run regressors
-    '''
-
+    """
     onset = []
     duration = []
     conds = []
@@ -64,9 +66,9 @@ def make_paradigm(event_files, num_vols, tr=2., cond_col=2, label_col=None, regr
             reader = csv.reader(f, delimiter='\t')
             header = reader.next()
             for row in reader:
-                if not regressors is None and not row[cond_col] in regressors:
+                if regressors is not None and row[cond_col] not in regressors:
                     continue
-                if not ignore_col is None:
+                if ignore_col is not None:
                     if row[ignore_col] in ignore_value:
                         continue
                 trial_count += 1
@@ -76,7 +78,7 @@ def make_paradigm(event_files, num_vols, tr=2., cond_col=2, label_col=None, regr
                     conds.append('trial-%06d' % trial_count)
                 else:
                     conds.append(row[cond_col])
-                if not label_col is None:
+                if label_col is not None:
                     labels.append(row[label_col])
 
         # Run regressors

--- a/bdpy/mri/image.py
+++ b/bdpy/mri/image.py
@@ -1,16 +1,16 @@
-'''bdpy.mri.image'''
+"""bdpy.mri.image"""
 
 
 from itertools import product
 
-import numpy as np
 import nibabel
+import numpy as np
 
 from bdpy.mri import load_mri
 
 
 def export_brain_image(brain_data, template, xyz=None, out_file=None):
-    '''Export a brain data array as a brain image.
+    """Export a brain data array as a brain image.
 
     Parameters
     ----------
@@ -24,8 +24,7 @@ def export_brain_image(brain_data, template, xyz=None, out_file=None):
     Returns
     -------
     nibabel.Nifti1Image
-    '''
-
+    """
     if brain_data.ndim == 1:
         brain_data = brain_data[np.newaxis, :]
 

--- a/bdpy/mri/load_epi.py
+++ b/bdpy/mri/load_epi.py
@@ -1,21 +1,17 @@
-'''Loading EPIs module.
+"""Loading EPIs module.
 
 This file is a part of BdPy.
-'''
+"""
 
 
 import itertools as itr
-import os
-import re
-import string
 
 import nipy
 import numpy as np
-import scipy.io as sio
 
 
 def load_epi(datafiles):
-    '''Load EPI files.
+    """Load EPI files.
 
     The returned data and xyz are flattened by C-like order.
 
@@ -31,8 +27,7 @@ def load_epi(datafiles):
         voxels).
     xyz_array: array_like, shape = (3, N)
         XYZ Coordiantes of voxels.
-    '''
-
+    """
     data_list = []
     xyz = np.array([])
 
@@ -51,8 +46,7 @@ def load_epi(datafiles):
 
 
 def _check_xyz(xyz, img):
-    '''Check voxel xyz consistency.'''
-
+    """Check voxel xyz consistency."""
     xyz_current = _get_xyz(img.coordmap.affine, img.get_data().shape)
 
     if xyz.size == 0:
@@ -64,7 +58,7 @@ def _check_xyz(xyz, img):
 
 
 def _get_xyz(affine, volume_shape):
-    '''Return voxel XYZ coordinates based on an affine matrix.
+    """Return voxel XYZ coordinates based on an affine matrix.
 
     Parameters
     ----------
@@ -77,8 +71,7 @@ def _get_xyz(affine, volume_shape):
     -------
     array, shape = (3, N)
         x-, y-, and z-coordinates (N: the number of voxels).
-    '''
-
+    """
     i_len, j_len, k_len = volume_shape
     ijk = np.array(list(itr.product(range(i_len),
                                     range(j_len),

--- a/bdpy/mri/load_mri.py
+++ b/bdpy/mri/load_mri.py
@@ -1,18 +1,18 @@
-'''load_mri'''
+"""load_mri"""
 
 
-import numpy as np
 import nipy
+import numpy as np
 
 
 def load_mri(fpath):
-    '''Load a MRI image.
+    """Load a MRI image.
 
     - Returns data as 2D array (sample x voxel)
     - Returns voxle xyz coordinates (3 x voxel)
     - Returns voxel ijk indexes (3 x voxel)
     - Data, xyz, and ijk are flattened by Fortran-like index order
-    '''
+    """
     img = nipy.load_image(fpath)
 
     data = img.get_data()

--- a/bdpy/mri/roi.py
+++ b/bdpy/mri/roi.py
@@ -1,13 +1,13 @@
-'''Utilities for ROIs'''
+"""Utilities for ROIs"""
 
 
-import os
 import glob
-import re
 import hashlib
+import os
+import re
 
-import numpy as np
 import nibabel.freesurfer
+import numpy as np
 
 from bdpy.mri import load_mri
 
@@ -19,7 +19,7 @@ def add_roimask(
         verbose=True,
         round=None
 ):
-    '''Add an ROI mask to `bdata`.
+    """Add an ROI mask to `bdata`.
 
     Parameters
     ----------
@@ -32,8 +32,7 @@ def add_roimask(
     Returns
     -------
     bdata : BData
-    '''
-
+    """
     if isinstance(roi_mask, str):
         roi_mask = [roi_mask]
 
@@ -101,7 +100,7 @@ def add_roimask(
 
 
 def get_roiflag(roi_xyz_list, epi_xyz_array, verbose=True):
-    '''Get ROI flags.
+    """Get ROI flags.
 
     Parameters
     ----------
@@ -117,8 +116,7 @@ def get_roiflag(roi_xyz_list, epi_xyz_array, verbose=True):
     -------
     roi_flag : array, shape = (n_rois, n_voxels)
         ROI flag array
-    '''
-
+    """
     epi_voxel_size = epi_xyz_array.shape[1]
 
     if verbose:
@@ -149,7 +147,7 @@ def get_roiflag(roi_xyz_list, epi_xyz_array, verbose=True):
 
 
 def add_roilabel(bdata, label, vertex_data=['VertexData'], prefix='', verbose=False):
-    '''Add ROI label(s) to `bdata`.
+    """Add ROI label(s) to `bdata`.
 
     Parameters
     ----------
@@ -160,7 +158,7 @@ def add_roilabel(bdata, label, vertex_data=['VertexData'], prefix='', verbose=Fa
     Returns
     -------
     bdata : BData
-    '''
+    """
 
     def add_roilabel_file(bdata, label, vertex_data=['VertexData'], prefix='', verbose=False):
         # Read the label file
@@ -236,8 +234,7 @@ def add_roilabel(bdata, label, vertex_data=['VertexData'], prefix='', verbose=Fa
 
 
 def add_rois(bdata, roi_files, data_type='volume', prefix_map={}, remove_voxel=True):
-    '''Add ROIs in bdata from files.'''
-
+    """Add ROIs in bdata from files."""
     roi_prefix_from_annot = {'lh.aparc.a2009s.annot': 'freesurfer_destrieux',
                              'rh.aparc.a2009s.annot': 'freesurfer_destrieux',
                              'lh.aparc.annot': 'freesurfer_dk',
@@ -315,8 +312,7 @@ def add_rois(bdata, roi_files, data_type='volume', prefix_map={}, remove_voxel=T
 
 
 def merge_rois(bdata, roi_name, merge_expr):
-    '''Merage ROIs.'''
-
+    """Merage ROIs."""
     print('Adding merged ROI %s' % roi_name)
 
     # Get tokens
@@ -388,14 +384,13 @@ def merge_rois(bdata, roi_name, merge_expr):
 
 
 def add_hcp_rois(bdata, overwrite=False):
-    '''Add HCP ROIs in `bdata`.
+    """Add HCP ROIs in `bdata`.
 
     Note
     ----
     This function assumes that the HCP ROIs (splitted by left and right) are
     named as "hcp180_r_lh.L_{}__*_ROI" and "hcp180_r_rh.R_{}__*_ROI".
-    '''
-
+    """
     hcp180_rois = [
         '1', '10d', '10pp', '10r', '10v', '11l', '13l', '2', '23c', '23d',
         '24dd', '24dv', '25', '31a', '31pd', '31pv', '33pr', '3a', '3b', '4',
@@ -467,8 +462,7 @@ def add_hcp_rois(bdata, overwrite=False):
 
 
 def add_hcp_visual_cortex(bdata, overwrite=False):
-    '''Add HCP-based visual cortex in `bdata`.'''
-
+    """Add HCP-based visual cortex in `bdata`."""
     # Whole VC
     vc_rois = [
         'V1', 'V2', 'V3', 'V4',

--- a/bdpy/mri/spm.py
+++ b/bdpy/mri/spm.py
@@ -1,15 +1,10 @@
 import csv
 import glob
-import itertools
 import os
 import re
-import json
 from collections import OrderedDict
 
 import numpy as np
-import nipy
-import nibabel
-import pandas as pd
 
 #import bdpy
 from .fmriprep import create_bdata_singlesubject
@@ -21,8 +16,7 @@ def create_bdata_spm_domestic(dpath, data_mode='volume_native',
                               with_confounds=False,
                               return_data_labels=False,
                               return_list=False):
-    '''Create BData from SPM outputs (Kamitani lab domestic data structure).'''
-
+    """Create BData from SPM outputs (Kamitani lab domestic data structure)."""
     print('BIDS data path: %s' % dpath)
 
     # Label mapper
@@ -84,7 +78,7 @@ def create_bdata_spm_domestic(dpath, data_mode='volume_native',
                 ex_runs = exclude['session/run'][i]
                 if ex_runs is not None and len(ex_runs) != 0:
                     run_survive = [run for j, run in enumerate(spm_out.data[sub][ses])
-                                   if not j + 1 in ex_runs]
+                                   if j + 1 not in ex_runs]
                     spm_out.data[sub][ses] = run_survive
 
     # Split data
@@ -156,7 +150,7 @@ def create_bdata_spm_domestic(dpath, data_mode='volume_native',
 
 
 class SpmDomestic(object):
-    '''SPM outputs (domestic data structure) class.'''
+    """SPM outputs (domestic data structure) class."""
 
     def __init__(self, datapath=None):
         self.__datapath = datapath

--- a/bdpy/opendata/openneuro.py
+++ b/bdpy/opendata/openneuro.py
@@ -1,15 +1,14 @@
+import json
 import os
 import re
 import shutil
-import json
 from glob import glob
 
 from bdpy import makedir_ifnot
 
 
 def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./', bids_dir='bids', fmap=False, dry_run=False):
-    '''Create BIDS dataset for OpenNeuro.'''
-
+    """Create BIDS dataset for OpenNeuro."""
     if not source_type == 'bids_daily':
         raise NotImplementedError('Source type %s not supported.' % source_type)
 
@@ -119,7 +118,7 @@ def makedata(src, source_type='bids_daily', output_dir='./output', root_dir='./'
 
                 # T2 inplane image
                 src_inplane = ses['inplane']
-                if not src_inplane is None:
+                if src_inplane is not None:
                     rename_table = {
                         os.path.basename(src_inplane).split('_')[0]: subject,       # SUbject ID
                         os.path.basename(src_inplane).split('_')[1]: session_label, # Session label
@@ -236,7 +235,7 @@ def __parse_bids_dir(dpath, data_info=None):
 
         # Session selection
         skip = False
-        if (not data_info is None) and 'ses' in data_info:
+        if (data_info is not None) and 'ses' in data_info:
             if isinstance(data_info['ses'], int) and (i + 1) != data_info['ses']:
                 skip = True
             elif isinstance(data_info['ses'], list) and (i + 1) not in data_info['ses']:
@@ -261,7 +260,7 @@ def __parse_bids_dir(dpath, data_info=None):
 
         # Run selection
         run_files_keep = []
-        if (not data_info is None) and 'discard_run' in data_info:
+        if (data_info is not None) and 'discard_run' in data_info:
             for j, rf in enumerate(run_files):
                 skip_run = False
                 if isinstance(data_info['discard_run'], int) and (j + 1) == data_info['discard_run']:

--- a/bdpy/pipeline/config.py
+++ b/bdpy/pipeline/config.py
@@ -2,12 +2,12 @@
 
 
 import argparse
-from pathlib import Path
 import inspect
 from datetime import datetime, timezone
+from pathlib import Path
 
-from hydra.experimental import initialize_config_dir, compose
-from omegaconf import OmegaConf, DictConfig
+from hydra.experimental import compose, initialize_config_dir
+from omegaconf import DictConfig, OmegaConf
 
 
 def init_hydra_cfg() -> DictConfig:

--- a/bdpy/preproc/__init__.py
+++ b/bdpy/preproc/__init__.py
@@ -6,5 +6,5 @@ This package is a part of BdPy
 
 
 from .interface import *
-from .select_top import *
 from .preprocessor import Preprocessor
+from .select_top import *

--- a/bdpy/preproc/interface.py
+++ b/bdpy/preproc/interface.py
@@ -5,8 +5,15 @@ This file is a part of BdPy
 """
 
 
-from .preprocessor import Average,Detrender,Normalize,Regressout,ReduceOutlier,ShiftSample
-from .util import print_start_msg, print_finish_msg
+from .preprocessor import (
+    Average,
+    Detrender,
+    Normalize,
+    ReduceOutlier,
+    Regressout,
+    ShiftSample,
+)
+from .util import print_finish_msg, print_start_msg
 
 
 def average_sample(x, group=[], verbose=True):
@@ -27,7 +34,6 @@ def average_sample(x, group=[], verbose=True):
     index_map : array_like
         Vector mapping row indexes from y to x (length = group num)
     """
-
     if verbose:
         print_start_msg()
 
@@ -56,7 +62,6 @@ def detrend_sample(x, group=[], keep_mean=True, verbose=True):
     y : array
         Detrended data array (group num * feature num)
     """
-
     if verbose:
         print_start_msg()
 
@@ -92,7 +97,6 @@ def normalize_sample(x, group=[], mode='PercentSignalChange', baseline='All',
     y : array
         Normalized data array (sample num * feature num)
     """
-
     if verbose:
         print_start_msg()
 
@@ -106,8 +110,7 @@ def normalize_sample(x, group=[], mode='PercentSignalChange', baseline='All',
 
 
 def reduce_outlier(x, group=[], std=True, maxmin=True, remove=False, dimension=1, n_iter=10, std_threshold=3, max_value=None, min_value=None, verbose=True):
-    '''Outlier reduction.'''
-
+    """Outlier reduction."""
     if verbose:
         print_start_msg()
 
@@ -124,7 +127,7 @@ def reduce_outlier(x, group=[], std=True, maxmin=True, remove=False, dimension=1
     
 
 def regressout(x, group=[], regressor=[], remove_dc=True, linear_detrend=True, verbose=True):
-    '''Remove nuisance regressors.
+    """Remove nuisance regressors.
 
     Parameters
     ----------
@@ -143,8 +146,7 @@ def regressout(x, group=[], regressor=[], remove_dc=True, linear_detrend=True, v
     -------
     y : array, shape = (n_sample, n_feature)
         Signal without nuisance regressors.
-    '''
-
+    """
     if verbose:
         print_start_msg()
 
@@ -179,7 +181,6 @@ def shift_sample(x, group=[], shift_size = 1, verbose = True):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> from bdpy.preproc import shift_sample
     >>> x = np.array([[ 1,  2,  3],
@@ -198,7 +199,6 @@ def shift_sample(x, group=[], shift_size = 1, verbose = True):
     >>> index
     array([0, 1, 3, 4])
     """
-
     if verbose:
         print_start_msg()
 

--- a/bdpy/preproc/preprocessor.py
+++ b/bdpy/preproc/preprocessor.py
@@ -6,11 +6,11 @@ This file is a part of BdPy.
 
 
 import copy
-import sys
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
 from numpy.matlib import repmat
+
 # NOTE: PendingDeprecationWarning: Importing from numpy.matlib is deprecated since 1.19.0.
 # repmat(a, m, n) is equivalent to tile(a, (m, n)). Use tile instead.
 # c.f. https://numpy.org/doc/stable/user/numpy-for-matlab-users.html
@@ -38,7 +38,6 @@ class Preprocessor(object):
         """
         Template method of preprocessing
         """
-
         # If `group` is empty, apply preprocessing to the whole data
         if len(group) == 0:
             group = np.ones(x.shape[0])

--- a/bdpy/preproc/select_top.py
+++ b/bdpy/preproc/select_top.py
@@ -7,9 +7,11 @@ This file is a part of BdPy.
 __all__ = ['select_top']
 
 
-from typing import Tuple, Optional
+from typing import Optional, Tuple
+
 import numpy as np
-from .util import print_start_msg, print_finish_msg
+
+from .util import print_finish_msg, print_start_msg
 
 
 def select_top(data: np.ndarray, value: np.ndarray, num: int, axis: Optional[int] = 0, verbose: Optional[bool] = True) -> Tuple[np.ndarray, np.ndarray]:

--- a/bdpy/recon/torch/icnn.py
+++ b/bdpy/recon/torch/icnn.py
@@ -1,4 +1,4 @@
-'''PyTorch implementation of iCNN reconstruction.
+"""PyTorch implementation of iCNN reconstruction.
 
 Contributions:
 
@@ -9,22 +9,21 @@ implementation as well as fixed bugs and improved performance.
 
 Developed and tested on Python 3.8 + PyTorch 1.7.1.
 
-'''
+"""
 
-
-from typing import Callable
 
 import os
 import warnings
+from typing import Callable
 
 import numpy as np
-from PIL import Image
 import torch
 import torch.optim as optim
+from PIL import Image
 
-from bdpy.dl.torch import FeatureExtractor
-from bdpy.recon.utils import make_feature_masks, gaussian_blur
 from bdpy.dataform import save_array
+from bdpy.dl.torch import FeatureExtractor
+from bdpy.recon.utils import gaussian_blur, make_feature_masks
 from bdpy.util import makedir_ifnot
 
 
@@ -70,7 +69,7 @@ def reconstruct(features,
                 return_generator_feature=False,
                 return_final_feat=False,
                 device='cpu'):
-    '''
+    """
     Reconstruction an image.
 
     Parameters
@@ -217,8 +216,7 @@ def reconstruct(features,
     ---------
     Shen et al. (2019) Deep image reconstruction from human brain activity.
         PLOS Computational Biology. https://doi.org/10.1371/journal.pcbi.1006633
-    '''
-
+    """
     if return_final_feat:
         warnings.warn('`return_final_feat` is deprecated and will be removed in future release. Please use `return_z` instead.', UserWarning)
     if return_generator_feature:

--- a/bdpy/recon/torch/modules/__init__.py
+++ b/bdpy/recon/torch/modules/__init__.py
@@ -1,5 +1,5 @@
-from .encoder import build_encoder, BaseEncoder
-from .generator import build_generator, BaseGenerator
+from .critic import BaseCritic, TargetNormalizedMSE
+from .encoder import BaseEncoder, build_encoder
+from .generator import BaseGenerator, build_generator
 from .latent import ArbitraryLatent, BaseLatent
-from .critic import TargetNormalizedMSE, BaseCritic
 from .optimizer import build_optimizer_factory, build_scheduler_factory

--- a/bdpy/recon/torch/modules/critic.py
+++ b/bdpy/recon/torch/modules/critic.py
@@ -6,8 +6,7 @@ from typing import Dict, Iterable
 import torch
 import torch.nn as nn
 
-from bdpy.task.callback import CallbackHandler, BaseCallback
-
+from bdpy.task.callback import BaseCallback, CallbackHandler
 
 _FeatureType = Dict[str, torch.Tensor]
 
@@ -60,6 +59,7 @@ class BaseCritic(ABC):
 
 class NNModuleCritic(BaseCritic, nn.Module):
     """Critic network module uses __call__ method of nn.Module."""
+
     def __init__(self, callbacks: BaseCallback | Iterable[BaseCallback] | None = None) -> None:
         BaseCritic.__init__(self, callbacks)
         nn.Module.__init__(self)

--- a/bdpy/recon/torch/modules/encoder.py
+++ b/bdpy/recon/torch/modules/encoder.py
@@ -5,6 +5,7 @@ from typing import Iterable
 
 import torch
 import torch.nn as nn
+
 from bdpy.dl.torch import FeatureExtractor
 from bdpy.dl.torch.domain import Domain, InternalDomain
 

--- a/bdpy/recon/torch/modules/generator.py
+++ b/bdpy/recon/torch/modules/generator.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import Callable, Iterator
-import warnings
 
 import torch
 import torch.nn as nn
 from torch.nn.parameter import Parameter
+
 from bdpy.dl.torch.domain import Domain, InternalDomain
 
 

--- a/bdpy/recon/torch/modules/generator.py
+++ b/bdpy/recon/torch/modules/generator.py
@@ -122,7 +122,7 @@ class BareGenerator(NNModuleGenerator):
         """Initialize the generator."""
         super().__init__()
         self._activation = activation
-        self._domain = InternalDomain()
+        self._domain: InternalDomain = InternalDomain()
 
     def reset_states(self) -> None:
         """Reset the state of the generator."""

--- a/bdpy/recon/torch/modules/optimizer.py
+++ b/bdpy/recon/torch/modules/optimizer.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 from functools import partial
 from itertools import chain
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict, Any, Tuple, Union, Iterable, Callable
-    from typing_extensions import TypeAlias
-    from torch import Tensor
+    from typing import Any, Callable, Dict, Iterable, Tuple, Union
+
     import torch.optim as optim
+    from torch import Tensor
+    from typing_extensions import TypeAlias
+
     from ..modules import BaseGenerator, BaseLatent
 
     # NOTE: The definition of `_ParamsT` is the same as in `torch.optim.optimizer`

--- a/bdpy/recon/torch/task/inversion.py
+++ b/bdpy/recon/torch/task/inversion.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable, Callable, TYPE_CHECKING
-
-from itertools import chain
+from typing import TYPE_CHECKING, Callable, Dict, Iterable
 
 from bdpy.task import BaseTask
-from bdpy.task.callback import BaseCallback, unused, _validate_callback
+from bdpy.task.callback import BaseCallback, unused
 
 if TYPE_CHECKING:
     import torch
 
-    from ..modules import BaseEncoder, BaseGenerator, BaseLatent, BaseCritic
+    from ..modules import BaseCritic, BaseEncoder, BaseGenerator, BaseLatent
     from ..modules.optimizer import _OptimizerFactoryType, _SchedulerFactoryType
 
     _FeatureType = Dict[str, torch.Tensor]

--- a/bdpy/recon/utils.py
+++ b/bdpy/recon/utils.py
@@ -1,4 +1,4 @@
-'''Reconstruction utilities.'''
+"""Reconstruction utilities."""
 
 
 import numpy as np
@@ -6,12 +6,11 @@ import scipy.ndimage as nd
 
 
 def clip_extreme(x, pct=1):
-    '''
+    """
     Clip extreme values.
 
     Original version was written by Shen Guo-Hua.
-    '''
-
+    """
     if pct < 0:
         pct = 0.
 
@@ -25,12 +24,11 @@ def clip_extreme(x, pct=1):
 
 
 def gaussian_blur(img, sigma):
-    '''
+    """
     Smooth the image with gaussian filter.
 
     Original version was written by Shen Guo-Hua.
-    '''
-
+    """
     if sigma > 0:
         img[0] = nd.filters.gaussian_filter(img[0], sigma, order=0)
         img[1] = nd.filters.gaussian_filter(img[1], sigma, order=0)
@@ -39,17 +37,17 @@ def gaussian_blur(img, sigma):
 
 
 def image_norm(img):
-    '''
+    """
     Calculate the norm of the RGB for each pixel.
 
     Original version was written by Shen Guo-Hua.
-    '''
+    """
     img_norm = np.sqrt(img[0] ** 2 + img[1] ** 2 + img[2] ** 2)
     return img_norm
 
 
 def normalize_image(img):
-    '''
+    """
     Normalize the image.
 
     Map the minimum pixel to 0; map the maximum pixel to 255.
@@ -57,8 +55,7 @@ def normalize_image(img):
 
 
     Original version was written by Shen Guo-Hua.
-    '''
-
+    """
     img = img - img.min()
     if img.max() > 0:
         img = img * (255.0 / img.max())
@@ -67,8 +64,7 @@ def normalize_image(img):
 
 
 def make_feature_masks(features, masks, channels):
-    '''Make feature masks.
-
+    """Make feature masks.
 
     Parameters
     ----------
@@ -104,8 +100,7 @@ def make_feature_masks(features, masks, channels):
     ----
     Original version was written by Shen Guo-Hua.
 
-    '''
-
+    """
     feature_masks = {}
     for layer in features.keys():
         if (masks is None or masks == {} or masks == [] or (layer not in masks.keys())) and (channels is None or channels == {} or channels == [] or (layer not in channels.keys())):  # use all features and all channels

--- a/bdpy/task/callback.py
+++ b/bdpy/task/callback.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Callable, Type, Any, Iterable, TypeVar, Generic
-from typing_extensions import Annotated, ParamSpec
-
 from collections import defaultdict
 from functools import wraps
+from typing import Any, Callable, Generic, Iterable, Type, TypeVar
 
+from typing_extensions import Annotated, ParamSpec
 
 _P = ParamSpec("_P")
 _Unused = Annotated[None, "unused"]
@@ -98,7 +97,6 @@ def _validate_callback(callback: BaseCallback, base_class: Type[BaseCallback]) -
         ...
         ValueError: on_unacceptable_event is not an acceptable event type. ...
     """
-
     if not isinstance(callback, base_class):
         raise TypeError(
             f"Callback must be an instance of {base_class}, not {type(callback)}."
@@ -152,6 +150,7 @@ class BaseCallback:
     `@unused` decorator can be used to mark a callback function as unused, so
     that the callback handler does not fire the function.
     """
+
     def __init__(self, base_class: Type[BaseCallback] | None = None) -> None:
         if base_class is None:
             base_class = BaseCallback

--- a/bdpy/task/core.py
+++ b/bdpy/task/core.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any, Generic, Iterable, TypeVar
 
-from typing import Iterable, Any, TypeVar, Generic
-
-from bdpy.task.callback import CallbackHandler, BaseCallback
-
+from bdpy.task.callback import BaseCallback, CallbackHandler
 
 _CallbackType = TypeVar("_CallbackType", bound=BaseCallback)
 

--- a/bdpy/util/__init__.py
+++ b/bdpy/util/__init__.py
@@ -4,6 +4,6 @@ This package is a part of BdPy.
 """
 
 
-from .utils import create_groupvector, divide_chunks, get_refdata, makedir_ifnot
 from .info import dump_info
 from .math import average_elemwise
+from .utils import create_groupvector, divide_chunks, get_refdata, makedir_ifnot

--- a/bdpy/util/info.py
+++ b/bdpy/util/info.py
@@ -1,17 +1,17 @@
 """Information module."""
 
 
-from typing import Dict, Optional
-
 import datetime
 import hashlib
 import os
+import pwd
 import sys
 import time
 import uuid
 import warnings
+from typing import Dict, Optional
+
 import yaml
-import pwd
 
 
 def dump_info(output_dir: str, script: Optional[str] = None, parameters: Optional[Dict] = None, info_file: str ='info.yaml') -> Dict:

--- a/bdpy/util/utils.py
+++ b/bdpy/util/utils.py
@@ -6,17 +6,15 @@ This file is a part of BdPy.
 
 from __future__ import division
 
-
 __all__ = ['create_groupvector',
            'divide_chunks',
            'get_refdata',
            'makedir_ifnot']
 
 
-from typing import List, Union
-
 import os
 import warnings
+from typing import List, Union
 
 import numpy as np
 

--- a/bdpy/util/utils.py
+++ b/bdpy/util/utils.py
@@ -43,7 +43,7 @@ def create_groupvector(group_label: Union[List, np.ndarray], group_size: Union[L
         >>> bdpy.util.create_groupvector([ 1, 2, 3 ], [ 2, 4, 2 ])
         array([1, 1, 2, 2, 2, 2, 3, 3])
     """
-    group_vector = []
+    group_vector: list = []
 
     if isinstance(group_size, int):
         # When 'group_size' is integer, create array in which each group label

--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,12 @@ ignore_missing_imports = True
 
 [mypy-sklearn.*]
 ignore_missing_imports = True
+
+[mypy-yaml]
+ignore_missing_imports = True
+
+[mypy-tqdm]
+ignore_missing_imports = True
+
+[mypy-seaborn]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,3 +20,21 @@ ignore_missing_imports = True
 
 [mypy-hdf5storage]
 ignore_missing_imports = True
+
+[mypy-nibabel]
+ignore_missing_imports = True
+
+[mypy-nibabel.*]
+ignore_missing_imports = True
+
+[mypy-nipy]
+ignore_missing_imports = True
+
+[mypy-nipy.*]
+ignore_missing_imports = True
+
+[mypy-torchvision.*]
+ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True

--- a/tests/dl/torch/domain/test_core.py
+++ b/tests/dl/torch/domain/test_core.py
@@ -130,7 +130,7 @@ class TestKeyValueDomain(unittest.TestCase):
 
 if __name__ == "__main__":
     #unittest.main()
-    composed_domain = core_module.ComposedDomain([
+    composed_domain: core_module.ComposedDomain = core_module.ComposedDomain([
         DummyDoubleDomain(),
         DummyAddDomain(),
     ])


### PR DESCRIPTION
CI ruff and mypy jobs are failing on `dev`. This PR applies only changes that can be made mechanically — no logic changes, no manual type annotations, no docstrings. pytest (218 tests) is untouched.

## Changes

**ruff** — `ruff check --fix` only (no `--unsafe-fixes`). −342 violations across 69 files: import sorting, docstring quote style, blank lines, unused imports, comparison style, trailing semicolons, etc. 1504 violations remain, mostly ANN/D requiring hand-written annotations and docstrings.

**mypy** — Added `ignore_missing_imports` to `mypy.ini` for libraries without a `py.typed` marker (`nibabel`, `nipy`, `torchvision.*`, `sklearn.*`, `yaml`, `tqdm`, `seaborn`), following the same pattern already in place for `numpy`, `scipy`, `pandas`, etc. Also added unambiguous type annotations to fix 7 `[var-annotated]` errors. −31 errors (113 → 82).

## Intentionally left out

- **ruff `--unsafe-fixes`** (266 candidates): ruff's own classification for fixes that may not preserve semantics. Needs per-hunk review before applying.
- **Missing type annotations and docstrings (~1370)**: the bulk of remaining ruff errors. Not automatable — require writing annotations and docstrings by hand for each function and class.
- **Capital variable names** (`X`, `Y`, `W`, etc., ~46 cases): ruff flags these as non-PEP8, but they are standard ML/scientific notation for matrices. Renaming to lowercase would change the meaning of the code, not just the style.
- **Legacy `np.random` API** (3 cases): ruff recommends migrating to the newer Generator API, but doing so silently changes the random number stream, which can break reproducibility of existing results.
- **Mutable default arguments** (56 cases): ruff recommends replacing `def f(x=[]):` with `def f(x=None):` + a None-guard inside. This changes function signatures and is not a safe mechanical fix.
- **mypy type mismatches (~73)**: genuine errors where the declared types and actual types don't agree (`arg-type`, `return-value`, `union-attr`, etc.). Require reading and fixing each site manually.

---

🤖 Generated with [Claude Code](https://claude.ai/code)
