### PR TITLE
fix(ci): handle coverage comments for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "dev" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -43,9 +46,18 @@ jobs:
             --cov-report=term-missing:skip-covered --cov=bdpy tests | tee pytest-coverage.txt
         )
 
-    - name: Upload coverage comment
-      if: always()
-      uses: MishaKav/pytest-coverage-comment@v1.7.2
+    - name: Save PR number
+      if: ${{ always() && github.event_name == 'pull_request' && matrix.python-version == '3.11' }}
+      run: |
+        echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+    - name: Upload coverage artifact
+      if: ${{ always() && github.event_name == 'pull_request' && matrix.python-version == '3.11' }}
+      uses: actions/upload-artifact@v7
       with:
-        pytest-coverage-path: pytest-coverage.txt
-        junitxml-path: pytest.yml
+        name: coverage-report
+        path: |
+          pytest-coverage.txt
+          pytest.yml
+          pr_number.txt
+        retention-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Python version used to collect and report coverage (single source of truth).
+  COVERAGE_PYTHON: "3.11"
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -47,12 +51,12 @@ jobs:
         )
 
     - name: Save PR number
-      if: ${{ always() && github.event_name == 'pull_request' && matrix.python-version == '3.11' }}
+      if: ${{ always() && github.event_name == 'pull_request' && matrix.python-version == env.COVERAGE_PYTHON }}
       run: |
         echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
     - name: Upload coverage artifact
-      if: ${{ always() && github.event_name == 'pull_request' && matrix.python-version == '3.11' }}
+      if: ${{ always() && github.event_name == 'pull_request' && matrix.python-version == env.COVERAGE_PYTHON }}
       uses: actions/upload-artifact@v7
       with:
         name: coverage-report

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -39,7 +39,7 @@ jobs:
         echo "number=$number" >> "$GITHUB_OUTPUT"
 
     - name: Upload coverage comment
-      uses: MishaKav/pytest-coverage-comment@v1.7.2
+      uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451 # v1.7.2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         issue-number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,47 @@
+name: coverage-comment
+
+on:
+  workflow_run:
+    workflows: [ "ci" ]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    # Do not checkout or execute PR code in this workflow; it can write PR comments.
+    - name: Download coverage artifact
+      uses: actions/download-artifact@v8
+      with:
+        name: coverage-report
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: coverage-report
+
+    - name: Read PR number
+      id: pr
+      run: |
+        number="$(tr -d '[:space:]' < coverage-report/pr_number.txt)"
+        case "$number" in
+          ''|*[!0-9]*)
+            echo "::error::Invalid PR number in coverage artifact"
+            exit 1
+            ;;
+        esac
+        echo "number=$number" >> "$GITHUB_OUTPUT"
+
+    - name: Upload coverage comment
+      uses: MishaKav/pytest-coverage-comment@v1.7.2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ steps.pr.outputs.number }}
+        pytest-coverage-path: coverage-report/pytest-coverage.txt
+        junitxml-path: coverage-report/pytest.yml


### PR DESCRIPTION
## Summary

This PR fixes coverage comment failures for pull requests opened from forks.

Fork PRs run the `pull_request` workflow with a read-only `GITHUB_TOKEN`, so tests can pass while `MishaKav/pytest-coverage-comment` fails to create or update the PR comment with `Resource not accessible by integration`.

## Changes

- Keep tests in the unprivileged `pull_request` `ci` workflow.
- Upload the Python 3.11 coverage output, JUnit XML, and PR number as a `coverage-report` artifact.
- Add a separate `coverage-comment` workflow triggered by `workflow_run`.
- Post the coverage comment from the base repository context without checking out or executing PR code.

## Security

This intentionally avoids `pull_request_target`, because the test workflow installs and runs PR-provided code.

The new `coverage-comment` workflow has permission to write PR comments, so it only reads artifact data and does not checkout, install, or execute PR code.

## Note

`workflow_run` workflows must exist on the repository default branch to run. This PR targets `dev`, while the default branch is `main`, so maintainers should also ensure `.github/workflows/coverage-comment.yml` exists on `main`.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/coverage-comment.yml`
- `git diff --check`

I have not verified this by running the workflow on GitHub Actions yet.

---

PR body drafted by Codex.
