### PR TITLE
chore: ignore root uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ test_versions
 /venv
 /venv-*
 /.venv
+/uv.lock
 
 *.code-workspace
 


### PR DESCRIPTION
## Summary

Ignore the root `uv.lock` file generated by local uv workflows.

BdPy currently does not use `uv.lock` as a source of truth: CI installs dependencies from `pyproject.toml` using pip, so a locally generated lockfile should not be accidentally committed.

If the project decides to follow uv's recommendation and track `uv.lock`, I will withdraw this PR.