### PR TITLE
refactor(mri): replace nipy image I/O with nibabel and deprecate nipy GLM paradigm helper

### DIFF
--- a/bdpy/mri/fmriprep.py
+++ b/bdpy/mri/fmriprep.py
@@ -11,7 +11,6 @@ import warnings
 from collections import OrderedDict
 
 import nibabel
-import nipy
 import numpy as np
 import pandas as pd
 
@@ -406,17 +405,17 @@ class BrainData(object):
         - Returns voxel ijk indexes (3 x voxel)
         - Data, xyz, and ijk are flattened by Fortran-like index order
         """
-        img = nipy.load_image(self.__dpath)
+        img = nibabel.load(self.__dpath)
 
         data = img.get_fdata()
         if data.ndim == 4:
             data = data.reshape(-1, data.shape[-1], order='F').T
             i_len, j_len, k_len, t = img.shape
-            affine = np.delete(np.delete(img.coordmap.affine, 3, axis=0), 3, axis=1)
+            affine = np.delete(np.delete(img.affine, 3, axis=0), 3, axis=1)
         elif data.ndim == 3:
             data = data.flatten(order='F')
             i_len, j_len, k_len = img.shape
-            affine = img.coordmap.affine
+            affine = img.affine
         else:
             raise ValueError('Invalid shape.')
 
@@ -838,17 +837,17 @@ def __load_mri(fpath):
     - Returns voxel ijk indexes (3 x voxel)
     - Data, xyz, and ijk are flattened by Fortran-like index order
     """
-    img = nipy.load_image(fpath)
+    img = nibabel.load(fpath)
 
     data = img.get_fdata()
     if data.ndim == 4:
         data = data.reshape(-1, data.shape[-1], order='F').T
         i_len, j_len, k_len, t = img.shape
-        affine = np.delete(np.delete(img.coordmap.affine, 3, axis=0), 3, axis=1)
+        affine = np.delete(np.delete(img.affine, 3, axis=0), 3, axis=1)
     elif data.ndim == 3:
         data = data.flatten(order='F')
         i_len, j_len, k_len = img.shape
-        affine = img.coordmap.affine
+        affine = img.affine
     else:
         raise ValueError('Invalid shape.')
 

--- a/bdpy/mri/fmriprep.py
+++ b/bdpy/mri/fmriprep.py
@@ -411,7 +411,7 @@ class BrainData(object):
         if data.ndim == 4:
             data = data.reshape(-1, data.shape[-1], order='F').T
             i_len, j_len, k_len, t = img.shape
-            affine = np.delete(np.delete(img.affine, 3, axis=0), 3, axis=1)
+            affine = img.affine
         elif data.ndim == 3:
             data = data.flatten(order='F')
             i_len, j_len, k_len = img.shape

--- a/bdpy/mri/glm.py
+++ b/bdpy/mri/glm.py
@@ -2,6 +2,7 @@
 
 
 import csv
+import warnings
 
 import numpy as np
 from nipy.modalities.fmri.experimental_paradigm import (
@@ -45,6 +46,14 @@ def make_paradigm(event_files, num_vols, tr=2., cond_col=2, label_col=None, regr
         run_regressors : nuisance regressors for runs
         run_regressors_label : labels for the run regressors
     """
+    warnings.warn(
+        "make_paradigm depends on nipy, which is unmaintained. nipy support "
+        "will be removed in a future release of bdpy. Consider migrating to "
+        "nilearn (e.g. nilearn.glm.first_level.make_first_level_design_matrix).",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     onset = []
     duration = []
     conds = []

--- a/bdpy/mri/load_epi.py
+++ b/bdpy/mri/load_epi.py
@@ -6,7 +6,7 @@ This file is a part of BdPy.
 
 import itertools as itr
 
-import nipy
+import nibabel
 import numpy as np
 
 
@@ -35,7 +35,7 @@ def load_epi(datafiles):
         print("Loading %s" % df)
 
         # Load an EPI image
-        img = nipy.load_image(df)
+        img = nibabel.load(df)
 
         xyz = _check_xyz(xyz, img)
         data_list.append(np.array(img.get_fdata().flatten(), dtype=np.float64))
@@ -49,7 +49,7 @@ def _check_xyz(xyz, img):
     """Check voxel xyz consistency."""
     # Use the image shape metadata; avoid get_fdata() here, which would read the
     # whole volume just to check consistency (load_epi reads the data later).
-    xyz_current = _get_xyz(img.coordmap.affine, img.shape[:3])
+    xyz_current = _get_xyz(img.affine, img.shape[:3])
 
     if xyz.size == 0:
         xyz = xyz_current

--- a/bdpy/mri/load_mri.py
+++ b/bdpy/mri/load_mri.py
@@ -19,7 +19,7 @@ def load_mri(fpath):
     if data.ndim == 4:
         data = data.reshape(-1, data.shape[-1], order='F').T
         i_len, j_len, k_len, t = img.shape
-        affine = np.delete(np.delete(img.affine, 3, axis=0), 3, axis=1)
+        affine = img.affine
     elif data.ndim == 3:
         data = data.flatten(order='F')
         i_len, j_len, k_len = img.shape

--- a/bdpy/mri/load_mri.py
+++ b/bdpy/mri/load_mri.py
@@ -1,7 +1,7 @@
 """load_mri"""
 
 
-import nipy
+import nibabel
 import numpy as np
 
 
@@ -13,17 +13,17 @@ def load_mri(fpath):
     - Returns voxel ijk indexes (3 x voxel)
     - Data, xyz, and ijk are flattened by Fortran-like index order
     """
-    img = nipy.load_image(fpath)
+    img = nibabel.load(fpath)
 
     data = img.get_fdata()
     if data.ndim == 4:
         data = data.reshape(-1, data.shape[-1], order='F').T
         i_len, j_len, k_len, t = img.shape
-        affine = np.delete(np.delete(img.coordmap.affine, 3, axis=0), 3, axis=1)
+        affine = np.delete(np.delete(img.affine, 3, axis=0), 3, axis=1)
     elif data.ndim == 3:
         data = data.flatten(order='F')
         i_len, j_len, k_len = img.shape
-        affine = img.coordmap.affine
+        affine = img.affine
     else:
         raise ValueError('Invalid shape.')
 

--- a/tests/test_mri.py
+++ b/tests/test_mri.py
@@ -47,6 +47,94 @@ class TestMri(unittest.TestCase):
         self.assertEqual(xyz.shape, (3, arr.size))
         self.assertEqual(ijk.shape, (3, arr.size))
 
+    def test_load_mri_4d(self) -> None:
+        """Test load_mri on a 4D volume.
+
+        Guards a bug in the 4D path where the affine was reduced to 3x3 before
+        being applied to homogeneous (4 x N) voxel indices, raising a shape
+        mismatch. The 4D path must use the full 4x4 affine, just like the 3D
+        path, and return one row per time point.
+        """
+        import os
+        import tempfile
+
+        import nibabel
+
+        i_len, j_len, k_len, t_len = 2, 3, 4, 5
+        n_vox = i_len * j_len * k_len
+        arr = np.arange(n_vox * t_len, dtype=np.float32).reshape(
+            i_len, j_len, k_len, t_len)
+        affine = np.array([[2., 0., 0., -10.],
+                           [0., 2., 0., -12.],
+                           [0., 0., 2., -8.],
+                           [0., 0., 0., 1.]])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = os.path.join(tmpdir, 'test4d.nii.gz')
+            nibabel.save(nibabel.Nifti1Image(arr, affine=affine), fpath)
+            data, xyz, ijk = bmr.load_mri(fpath)  # type: ignore
+
+        # Data is (sample x voxel): one sample per time point, voxels flattened
+        # in Fortran order.
+        self.assertEqual(data.shape, (t_len, n_vox))
+        np.testing.assert_array_equal(
+            data, arr.reshape(-1, t_len, order='F').T)
+
+        # ijk are the voxel indices in Fortran order.
+        expected_ijk = np.array(np.unravel_index(
+            np.arange(n_vox), (i_len, j_len, k_len), order='F'))
+        np.testing.assert_array_equal(ijk, expected_ijk)
+
+        # xyz are the world coordinates from the full 4x4 affine.
+        ijk_b = np.vstack([expected_ijk, np.ones((1, n_vox))])
+        expected_xyz = np.dot(affine, ijk_b)[:3]
+        np.testing.assert_allclose(xyz, expected_xyz)
+        self.assertEqual(xyz.shape, (3, n_vox))
+
+    def test_braindata_load_volume_4d(self) -> None:
+        """Test BrainData volume loading on a 4D volume.
+
+        Guards the same 4D affine bug as test_load_mri_4d in the duplicated
+        loader inside fmriprep.BrainData.__load_volume. The surrounding
+        create_bdata_fmriprep code treats ``data.shape[0]`` as the number of
+        volumes (time points), so the 4D path must return ``(T, N)`` data and
+        spatial xyz from the full 4x4 affine.
+        """
+        import os
+        import tempfile
+
+        import nibabel
+
+        from bdpy.mri.fmriprep import BrainData
+
+        i_len, j_len, k_len, t_len = 2, 3, 4, 5
+        n_vox = i_len * j_len * k_len
+        arr = np.arange(n_vox * t_len, dtype=np.float32).reshape(
+            i_len, j_len, k_len, t_len)
+        affine = np.array([[2., 0., 0., -10.],
+                           [0., 2., 0., -12.],
+                           [0., 0., 2., -8.],
+                           [0., 0., 0., 1.]])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = os.path.join(tmpdir, 'bold4d.nii.gz')
+            nibabel.save(nibabel.Nifti1Image(arr, affine=affine), fpath)
+            brain = BrainData(fpath, dtype='volume')
+
+        # data.shape[0] must be the number of time points (volumes).
+        self.assertEqual(brain.data.shape, (t_len, n_vox))
+        np.testing.assert_array_equal(
+            brain.data, arr.reshape(-1, t_len, order='F').T)
+
+        expected_ijk = np.array(np.unravel_index(
+            np.arange(n_vox), (i_len, j_len, k_len), order='F'))
+        np.testing.assert_array_equal(brain.index, expected_ijk)
+
+        ijk_b = np.vstack([expected_ijk, np.ones((1, n_vox))])
+        expected_xyz = np.dot(affine, ijk_b)[:3]
+        np.testing.assert_allclose(brain.xyz, expected_xyz)
+        self.assertEqual(brain.xyz.shape, (3, n_vox))
+
     def test_get_roiflag_pass0002(self) -> None:
         """Test for get_roiflag (pass case 0002)."""
         roi_xyz = [np.array([[1, 2, 3],


### PR DESCRIPTION
### Summary

This PR mainly aims to **gradually reduce the dependency on `nipy`**, while also including a small fix for a **4D image-loading affine bug** found during the refactoring. The changes can be grouped into two parts:

1. **Replace `nipy` image I/O with `nibabel`, and deprecate the GLM paradigm helper** — the main purpose of this PR.
2. **Fix the 4D affine bug and add regression tests** — a small, related fix included in this PR.

> I can split the bug fix into a separate PR if preferred. However, since the affected code overlaps with the image-loading refactor and the actual fix is only a few lines, I included it here. The commits are separated into `refactor:` and `fix:` commits to make the scope easier to review.

### Background / Why

`bdpy[mri]` currently depends on `nipy`, which appears to be effectively unmaintained. This blocks support for newer Python versions, especially Python 3.14, because `nipy` does not provide a `cp314` wheel. See the related discussions in KamitaniLab/bdpy#68 and #120.

Rather than removing `nipy` all at once, this PR takes a staged approach:

* **Replace what can be replaced**: image I/O is migrated from `nipy` to `nibabel` while preserving behavior.
* **Deprecate what cannot yet be replaced cleanly**: the GLM paradigm helper still returns a `nipy`-specific paradigm object, so it is kept for now but marked as deprecated.

### What changed

#### 1. `refactor:` migrate image I/O to `nibabel` and deprecate the GLM helper

* Replaced `nipy.load_image` with `nibabel.load` in `load_mri.py`, `load_epi.py`, and `fmriprep.py`.
* Replaced `img.coordmap.affine` with `img.affine`.

Rationale for behavioral equivalence:

* For the target images, `nibabel`’s `img.affine` matches `nipy`’s `img.coordmap.affine`.
* The existing `image.py::export_brain_image` already relies on an exact float-level comparison between the two affine representations, which supports their equivalence in the current use case.
* I also confirmed locally that the loaded data, xyz coordinates, and ijk coordinates match between the `nipy` and `nibabel` code paths.

`glm.make_paradigm` is not migrated in this PR because it returns a `nipy`-specific paradigm object intended to be passed to the `nipy` GLM machinery. Instead, it now emits a `DeprecationWarning` and recommends migrating to `nilearn` in the future.

#### 2. `fix:` fix the 4D affine bug and add regression tests

The 4D loading path previously reduced the affine matrix from 4×4 to 3×3, but the downstream code multiplies it by homogeneous coordinates of shape 4×N. As a result, loading a 4D image always raised a `ValueError`. This was an existing bug independent of whether the backend was `nipy` or `nibabel`.

This PR fixes the bug by keeping the full 4×4 affine matrix.

The fix is applied only to the two actually used code paths:

* `load_mri.load_mri`
* `fmriprep.BrainData.__load_volume`

For the latter, I confirmed that this is the real volume-loading path: `create_bdata_fmriprep` treats `BrainData.data.shape[0]` as the number of volumes / time points, so the 4D branch returning data of shape `(T, N)` is the intended behavior.

Regression tests added:

* `test_load_mri_4d`
* `test_braindata_load_volume_4d`

### Intentionally not changed

* **`fmriprep.__load_mri` / `__get_xyz`**

These appear to be unused code paths with no caller in the current codebase. Although their affine-handling logic looks similar to the code changed in the active loading paths, I could not determine whether the current behavior is actually incorrect or intentional, because there is no concrete use case to verify against.

I therefore left them unchanged in this PR to avoid introducing an unverified behavior change. They can be revisited separately if needed.

  `__get_xyz` does not directly reference `nipy`, so it is left completely unchanged. Whether these unused functions should be removed can be discussed separately.

* **`pyproject.toml` / the `nipy` dependency**

  These are intentionally unchanged. Since `make_paradigm` still depends on `nipy`, the dependency remains in the `mri` / `all` extras for now. Fully removing `nipy` should be handled in a future release.

### Testing

* `pytest tests/test_mri.py` → 5 passed
* `ruff check bdpy/mri/` → no new errors; the result is unchanged before and after this PR
* Locally confirmed that the migrated `nibabel` paths produce results matching the previous `nipy` paths
