### PR TITLE
Support Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Shuntaro C. Aoki", email = "s_aoki@i.kyoto-u.ac.jp" }
 ]
 readme = "README.md"
-requires-python = ">= 3.8, < 3.12"
+requires-python = ">= 3.8, < 3.14"
 license = { file = "LICENSE" }
 keywords = ["neuroscience", "neuroimaging", "brain decoding", "fmri", "machine learning"]
 


### PR DESCRIPTION
Raise the `requires-python` upper bound to `< 3.14` and add Python 3.12 and 3.13 to the blocking CI matrix.

## Changes

- `pyproject.toml`: `requires-python` `>= 3.8, < 3.12` → `>= 3.8, < 3.14`
- `ci.yml`: blocking `test` matrix `["3.10", "3.11"]` → `["3.10", "3.11", "3.12", "3.13"]`

## Notes

Python 3.14 is intentionally left out: `nipy` (latest 0.6.1) does not yet provide a Python 3.14-compatible distribution. 

The remaining FastL2LiR CI failure appears to be caused by a PyFastL2LiR NumPy 2.4 compatibility issue, not by this PR. It matches
the upstream fix in KamitaniLab/PyFastL2LiR@2eef75d, which has not been released yet.

Refs #120