### PR TITLE
fix(bdata): stop embedding call stack and source code in saved headers

### DIFF
--- a/bdpy/bdata/bdata.py
+++ b/bdpy/bdata/bdata.py
@@ -888,21 +888,7 @@ class BData(object):
 
     def __save_h5(self, file_name: str, header: Optional[Dict[str, Any]] = None) -> None:
         """Save data in HDF5 format (*.h5)."""
-        # Remove legacy call-stack fields from the in-memory header so they are
-        # neither written out nor retained after a save. This runs on every
-        # save path, including the private `header=None` path used to skip the
-        # header group, so a file opened with an older version is sanitized
-        # regardless of how it is saved.
-        legacy_keys = [k for k in ('callstack', 'callstack_code') if k in self.__header]
-        if legacy_keys:
-            warnings.warn(
-                "Removing legacy header field(s) %s on save for privacy; "
-                "they will not be written to the file." % ', '.join(legacy_keys),
-                UserWarning,
-                stacklevel=3,
-            )
-            for k in legacy_keys:
-                del self.__header[k]
+        legacy_header_keys = ('callstack', 'callstack_code')
 
         with h5py.File(file_name, 'w') as h5file:
             # dataset
@@ -920,8 +906,26 @@ class BData(object):
 
             # header
             if header is not None:
+                # Omit legacy call-stack fields (absolute paths + full source
+                # code of the call stack) from the saved file for privacy.
+                # Neither self.__header nor the passed-in header dict is
+                # modified -- only the written copy is filtered.
+                legacy_keys = [k for k in legacy_header_keys if k in header]
+                if legacy_keys:
+                    warnings.warn(
+                        'Omitting legacy header field(s) {} from the saved file for privacy.'
+                        .format(', '.join(legacy_keys)),
+                        UserWarning,
+                        stacklevel=3,
+                    )
+
+                header_to_write = {
+                    k: v for k, v in header.items()
+                    if k not in legacy_header_keys
+                }
+
                 h5file.create_group('/header')
-                for header_key, header_value in header.items():
+                for header_key, header_value in header_to_write.items():
                     if isinstance(header_value, list):
                         h5file.create_dataset(
                             '/header/' + header_key,

--- a/bdpy/bdata/bdata.py
+++ b/bdpy/bdata/bdata.py
@@ -9,7 +9,6 @@ __all__ = ['BData']
 
 import datetime
 import functools
-import inspect
 import os
 import re
 import time
@@ -142,8 +141,8 @@ class BData(object):
     def header(self) -> Dict[str, Any]:
         """Header information associated with the BData instance.
 
-        The header stores auxiliary information such as creation time,
-        call stack, and values loaded from BData files.
+        The header stores auxiliary information such as creation time
+        and values loaded from BData files.
         Header keys are strings, while values are implementation-defined and
         may include strings, numbers, lists, or values loaded from
         external files.
@@ -823,33 +822,30 @@ class BData(object):
 
     def save(self, file_name: str, file_type: Optional[str] = None) -> None:
         """Save 'dataset' and 'metadata' to a file."""
-        # Store data creation information
+        # Store data creation information.
+        # Note: older versions of bdpy also embedded the call stack (absolute
+        # file paths) and the full source code of every file on it into the
+        # header. That can leak sensitive information (internal paths,
+        # unpublished code) when BData files are shared, so it is no longer
+        # collected; only the creation time is recorded.
         t_now = time.time()
         t_now_str = datetime.datetime.fromtimestamp(t_now).strftime('%Y-%m-%d %H:%M:%S')
 
-        callstack = []
-        callstack_code = []
-        f = inspect.currentframe()
-        if f is None:
-            raise RuntimeError('Failed to get the current frame for call stack information.')
-        while True:
-            f = f.f_back
-            if f is None:
-                break
-            fname = os.path.abspath(f.f_code.co_filename)
-            fline = f.f_lineno
-            callstack.append('%s:%d' % (fname, fline))
-            if os.path.exists(fname):
-                with open(fname, 'r') as fl:
-                    fcode = fl.read()
-            else:
-                fcode = ''
-            callstack_code.append(fcode)
-
         self.__header.update({'ctime': t_now_str,
-                              'ctime_epoch': t_now,
-                              'callstack': callstack,
-                              'callstack_code': callstack_code})
+                              'ctime_epoch': t_now})
+
+        # Strip legacy call-stack fields that may have been loaded from a file
+        # saved by an older version, so they are not written out again.
+        legacy_keys = [k for k in ('callstack', 'callstack_code') if k in self.__header]
+        if legacy_keys:
+            warnings.warn(
+                "Removing legacy header field(s) %s on save for privacy; "
+                "they will not be written to the file." % ', '.join(legacy_keys),
+                UserWarning,
+                stacklevel=2,
+            )
+            for k in legacy_keys:
+                del self.__header[k]
 
         if file_type is None:
             file_type = self.__get_filetype(file_name)

--- a/bdpy/bdata/bdata.py
+++ b/bdpy/bdata/bdata.py
@@ -834,19 +834,6 @@ class BData(object):
         self.__header.update({'ctime': t_now_str,
                               'ctime_epoch': t_now})
 
-        # Strip legacy call-stack fields that may have been loaded from a file
-        # saved by an older version, so they are not written out again.
-        legacy_keys = [k for k in ('callstack', 'callstack_code') if k in self.__header]
-        if legacy_keys:
-            warnings.warn(
-                "Removing legacy header field(s) %s on save for privacy; "
-                "they will not be written to the file." % ', '.join(legacy_keys),
-                UserWarning,
-                stacklevel=2,
-            )
-            for k in legacy_keys:
-                del self.__header[k]
-
         if file_type is None:
             file_type = self.__get_filetype(file_name)
 
@@ -901,6 +888,22 @@ class BData(object):
 
     def __save_h5(self, file_name: str, header: Optional[Dict[str, Any]] = None) -> None:
         """Save data in HDF5 format (*.h5)."""
+        # Remove legacy call-stack fields from the in-memory header so they are
+        # neither written out nor retained after a save. This runs on every
+        # save path, including the private `header=None` path used to skip the
+        # header group, so a file opened with an older version is sanitized
+        # regardless of how it is saved.
+        legacy_keys = [k for k in ('callstack', 'callstack_code') if k in self.__header]
+        if legacy_keys:
+            warnings.warn(
+                "Removing legacy header field(s) %s on save for privacy; "
+                "they will not be written to the file." % ', '.join(legacy_keys),
+                UserWarning,
+                stacklevel=3,
+            )
+            for k in legacy_keys:
+                del self.__header[k]
+
         with h5py.File(file_name, 'w') as h5file:
             # dataset
             h5file.create_dataset('/dataset', data=self.dataset)

--- a/tests/bdata/test_bdata.py
+++ b/tests/bdata/test_bdata.py
@@ -262,6 +262,45 @@ class TestBdata(unittest.TestCase):
         self.assertEqual(loaded_bdata.header['indices'], [1, 2])
         self.assertEqual(loaded_bdata.header['scale'], 1.5)
 
+    def test_save_no_callstack_header(self):
+        '''save() records creation time but no call-stack information.'''
+        bdata = BData()
+        bdata.add(np.arange(6, dtype=float).reshape(3, 2), 'Data')
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            h5_path = os.path.join(temp_dir, 'test_bdata.h5')
+            bdata.save(h5_path, 'HDF5')
+            loaded_bdata = BData(h5_path, 'HDF5')
+
+        self.assertIn('ctime', loaded_bdata.header)
+        self.assertIn('ctime_epoch', loaded_bdata.header)
+        self.assertNotIn('callstack', loaded_bdata.header)
+        self.assertNotIn('callstack_code', loaded_bdata.header)
+
+    def test_save_strips_legacy_callstack(self):
+        '''save() drops legacy call-stack header fields and warns.'''
+        bdata = BData()
+        bdata.add(np.arange(6, dtype=float).reshape(3, 2), 'Data')
+        bdata.update_header({
+            'source': 'manual',
+            'callstack': ['/abs/path/to/script.py:42'],
+            'callstack_code': ['secret source code'],
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            h5_path = os.path.join(temp_dir, 'test_bdata.h5')
+            with self.assertWarns(UserWarning):
+                bdata.save(h5_path, 'HDF5')
+            loaded_bdata = BData(h5_path, 'HDF5')
+
+        # Legacy fields are stripped both in memory and in the saved file,
+        # while intentionally set header fields survive.
+        self.assertNotIn('callstack', bdata.header)
+        self.assertNotIn('callstack_code', bdata.header)
+        self.assertNotIn('callstack', loaded_bdata.header)
+        self.assertNotIn('callstack_code', loaded_bdata.header)
+        self.assertEqual(loaded_bdata.header['source'], 'manual')
+
     # Tests for vmap
     def test_vmap_add_get(self):
         bdata = BData()

--- a/tests/bdata/test_bdata.py
+++ b/tests/bdata/test_bdata.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 import warnings
 
+import h5py
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -300,6 +301,29 @@ class TestBdata(unittest.TestCase):
         self.assertNotIn('callstack', loaded_bdata.header)
         self.assertNotIn('callstack_code', loaded_bdata.header)
         self.assertEqual(loaded_bdata.header['source'], 'manual')
+
+    def test_save_h5_header_none_strips_legacy_inplace(self):
+        '''__save_h5(header=None) writes no header group but still cleans memory.'''
+        bdata = BData()
+        bdata.add(np.arange(6, dtype=float).reshape(3, 2), 'Data')
+        bdata.update_header({
+            'source': 'manual',
+            'callstack': ['/abs/path/to/script.py:42'],
+            'callstack_code': ['secret source code'],
+        })
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            h5_path = os.path.join(temp_dir, 'test_bdata.h5')
+            with self.assertWarns(UserWarning):
+                bdata._BData__save_h5(h5_path, header=None)
+            with h5py.File(h5_path, 'r') as f:
+                self.assertNotIn('header', f)
+
+        # Legacy fields are stripped from the in-memory header even though no
+        # header group was written, while other fields are kept.
+        self.assertNotIn('callstack', bdata.header)
+        self.assertNotIn('callstack_code', bdata.header)
+        self.assertEqual(bdata.header['source'], 'manual')
 
     # Tests for vmap
     def test_vmap_add_get(self):

--- a/tests/bdata/test_bdata.py
+++ b/tests/bdata/test_bdata.py
@@ -278,8 +278,8 @@ class TestBdata(unittest.TestCase):
         self.assertNotIn('callstack', loaded_bdata.header)
         self.assertNotIn('callstack_code', loaded_bdata.header)
 
-    def test_save_strips_legacy_callstack(self):
-        '''save() drops legacy call-stack header fields and warns.'''
+    def test_save_excludes_legacy_callstack_from_file(self):
+        '''save() omits legacy call-stack fields from the file but keeps them in memory.'''
         bdata = BData()
         bdata.add(np.arange(6, dtype=float).reshape(3, 2), 'Data')
         bdata.update_header({
@@ -294,16 +294,17 @@ class TestBdata(unittest.TestCase):
                 bdata.save(h5_path, 'HDF5')
             loaded_bdata = BData(h5_path, 'HDF5')
 
-        # Legacy fields are stripped both in memory and in the saved file,
-        # while intentionally set header fields survive.
-        self.assertNotIn('callstack', bdata.header)
-        self.assertNotIn('callstack_code', bdata.header)
+        # Legacy fields are omitted from the saved file, but the in-memory
+        # header is left untouched; intentionally set fields survive both.
         self.assertNotIn('callstack', loaded_bdata.header)
         self.assertNotIn('callstack_code', loaded_bdata.header)
         self.assertEqual(loaded_bdata.header['source'], 'manual')
+        self.assertIn('callstack', bdata.header)
+        self.assertIn('callstack_code', bdata.header)
+        self.assertEqual(bdata.header['source'], 'manual')
 
-    def test_save_h5_header_none_strips_legacy_inplace(self):
-        '''__save_h5(header=None) writes no header group but still cleans memory.'''
+    def test_save_h5_header_none_keeps_memory(self):
+        '''__save_h5(header=None) writes no header group and leaves memory intact.'''
         bdata = BData()
         bdata.add(np.arange(6, dtype=float).reshape(3, 2), 'Data')
         bdata.update_header({
@@ -314,15 +315,17 @@ class TestBdata(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as temp_dir:
             h5_path = os.path.join(temp_dir, 'test_bdata.h5')
-            with self.assertWarns(UserWarning):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
                 bdata._BData__save_h5(h5_path, header=None)
             with h5py.File(h5_path, 'r') as f:
                 self.assertNotIn('header', f)
 
-        # Legacy fields are stripped from the in-memory header even though no
-        # header group was written, while other fields are kept.
-        self.assertNotIn('callstack', bdata.header)
-        self.assertNotIn('callstack_code', bdata.header)
+        # No header is written, so nothing is omitted and no warning fires.
+        self.assertFalse([w for w in caught if issubclass(w.category, UserWarning)])
+        # The in-memory header is left fully intact.
+        self.assertIn('callstack', bdata.header)
+        self.assertIn('callstack_code', bdata.header)
         self.assertEqual(bdata.header['source'], 'manual')
 
     # Tests for vmap


### PR DESCRIPTION
## Summary

`BData.save()` previously embedded `callstack` and `callstack_code` in every saved
`.h5` file's `/header`. These fields include absolute file paths, line numbers,
and the full source code of files on the call stack, which can leak internal
paths or unpublished code when BData files are shared.

This PR stops writing those fields to saved files by default while keeping
`ctime` and `ctime_epoch`.

Closes #131.

## Changes

- Remove the `inspect`-based call-stack/source-code collection from `save()`.

- Omit legacy `callstack` / `callstack_code` fields from the header written to
  saved files, so old files become clean after load→save.

- Leave the in-memory `BData.header` unchanged when omitting those legacy fields
  from the saved file.

- Emit a `UserWarning` when legacy fields are present in a header being written
  and are omitted from the saved file.

- Keep user-set header fields, except that legacy `callstack` / `callstack_code`
  are not written to saved files.

## Behavior change

Newly saved files no longer contain `callstack` or `callstack_code`. Re-saving
older files writes a clean output file without those fields and emits a warning,
but does not remove them from the in-memory `BData.header`.

## Testing

- Added tests for new saves, legacy header omission, and preserving in-memory
  headers.

- `pytest tests/bdata/test_bdata.py` → 22 passed.