### PR TITLE
chore: remove unused private functions

### DIFF
--- a/bdpy/dataform/features.py
+++ b/bdpy/dataform/features.py
@@ -466,9 +466,6 @@ class DecodedFeatures(object):
 
         return db
 
-    def __init_db(self, keys):
-        raise NotImplementedError
-
 
 class FileDatabase(object):
     def __init__(self, keys: List[str]):

--- a/bdpy/dl/torch/dataset.py
+++ b/bdpy/dl/torch/dataset.py
@@ -12,31 +12,6 @@ from bdpy.dataform import DecodedFeatures, Features
 _FeatureTypeNP = Dict[str, np.ndarray]
 
 
-def _removesuffix(s: str, suffix: str) -> str:
-    """Remove suffix from string.
-
-    Note
-    ----
-    This function is available from Python 3.9 as `str.removesuffix`. We can
-    remove this function when we drop support for Python 3.8.
-
-    Parameters
-    ----------
-    s : str
-        String.
-    suffix : str
-        Suffix to remove.
-
-    Returns
-    -------
-    str
-        String without suffix.
-    """
-    if suffix and s.endswith(suffix):
-        return s[: -len(suffix)]
-    return s[:]
-
-
 class FeaturesDataset(Dataset):
     """Dataset of features.
 

--- a/bdpy/mri/fmriprep.py
+++ b/bdpy/mri/fmriprep.py
@@ -813,52 +813,6 @@ def __create_bdata_fmriprep_subject(subject_data, data_mode, data_path='./', lab
     return bdata
 
 
-def __get_xyz(img):
-    if len(img.shape) == 4:
-        # 4D-image
-        i_len, j_len, k_len, t = img.shape
-        affine = np.delete(np.delete(img.coordmap.affine, 3, axis=0), 3, axis=1)
-    else:
-        # 3D-image
-        i_len, j_len, k_len = img.shape
-        affine = img.coordmap.affine
-    ijk = np.array(list(itertools.product(range(i_len),
-                                          range(j_len),
-                                          range(k_len),
-                                          [1]))).T
-    return np.dot(affine, ijk)[:-1]
-
-
-def __load_mri(fpath):
-    """Load a MRI image.
-
-    - Returns data as 2D array (sample x voxel)
-    - Returns voxle xyz coordinates (3 x voxel)
-    - Returns voxel ijk indexes (3 x voxel)
-    - Data, xyz, and ijk are flattened by Fortran-like index order
-    """
-    img = nibabel.load(fpath)
-
-    data = img.get_fdata()
-    if data.ndim == 4:
-        data = data.reshape(-1, data.shape[-1], order='F').T
-        i_len, j_len, k_len, t = img.shape
-        affine = np.delete(np.delete(img.affine, 3, axis=0), 3, axis=1)
-    elif data.ndim == 3:
-        data = data.flatten(order='F')
-        i_len, j_len, k_len = img.shape
-        affine = img.affine
-    else:
-        raise ValueError('Invalid shape.')
-
-    ijk = np.array(np.unravel_index(np.arange(i_len * j_len * k_len),
-                                    (i_len, j_len, k_len), order='F'))
-    ijk_b = np.vstack([ijk, np.ones((1, i_len * j_len * k_len))])
-    xyz_b = np.dot(affine, ijk_b)
-    xyz = xyz_b[:-1]
-
-    return data, xyz, ijk
-
 
 if __name__ == '__main__':
     pass

--- a/bdpy/recon/torch/task/inversion.py
+++ b/bdpy/recon/torch/task/inversion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Dict, Iterable
+from typing import TYPE_CHECKING, Dict, Iterable
 
 from bdpy.task import BaseTask
 from bdpy.task.callback import BaseCallback, unused

--- a/bdpy/recon/torch/task/inversion.py
+++ b/bdpy/recon/torch/task/inversion.py
@@ -14,12 +14,6 @@ if TYPE_CHECKING:
     _FeatureType = Dict[str, torch.Tensor]
 
 
-def _apply_to_features(
-    fn: Callable[[torch.Tensor], torch.Tensor], features: _FeatureType
-) -> _FeatureType:
-    return {k: fn(v) for k, v in features.items()}
-
-
 class FeatureInversionCallback(BaseCallback):
     """Callback for feature inversion task.
 


### PR DESCRIPTION
## Summary

Remove private functions with no callers anywhere in the codebase.

| Function | File | Notes |
|---|---|---|
| `__get_xyz` | `bdpy/mri/fmriprep.py` | No callers; unused dead code |
| `__load_mri` | `bdpy/mri/fmriprep.py` | No callers; unused dead code |
| `DecodedFeatures.__init_db` | `bdpy/dataform/features.py` | No callers; raises `NotImplementedError` |
| `_apply_to_features` | `bdpy/recon/torch/task/inversion.py` | No callers |
| `_removesuffix` | `bdpy/dl/torch/dataset.py` | No callers; unused `str.removesuffix` wrapper |

`fmriprep.__load_mri` and `fmriprep.__get_xyz` were flagged as dead code to be removed separately in #138.

## Checks

Environment: Python 3.11.15, Linux x86_64 (glibc 2.39), numpy 2.4.6, scipy 1.17.1, h5py 3.16.0, hdf5storage 0.2.2

- `uv run pytest`: 135 passed, 1 pre-existing failure in `tests/ml/test_learning.py` (external dep `fastl2lir`, unrelated to this PR)
- `uv run ruff check`: pre-existing errors only; no new errors introduced
- `uv run mypy bdpy`: pre-existing errors only; no new errors introduced